### PR TITLE
[Feat] Common, 6대 카테고리 엔티티 추가, querydsl 의존성 추가, DB의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
+    // mariadb for server database
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    // h2 database for test
+    testImplementation 'com.h2database:h2'
+
     // querydsl for spring boot 3.x
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,40 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.2.3'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.jeju'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // querydsl for spring boot 3.x
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/jeju/nanaland/NanalandApplication.java
+++ b/src/main/java/com/jeju/nanaland/NanalandApplication.java
@@ -2,8 +2,10 @@ package com.jeju.nanaland;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NanalandApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/jeju/nanaland/domain/common/config/QuerydslConfig.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.jeju.nanaland.domain.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/BaseEntity.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.jeju.nanaland.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @MappedSuperclass
-public class Common {
+public class Common extends BaseEntity{
 
   private String imageUrl;
   private String contact;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -5,8 +5,9 @@ import lombok.Getter;
 
 @Getter
 @MappedSuperclass
-public class Common extends BaseEntity{
+public class Common extends BaseEntity {
 
   private String imageUrl;
+
   private String contact;
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -1,0 +1,12 @@
+package com.jeju.nanaland.domain.common.entity;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public class Common {
+
+  private String imageUrl;
+  private String contact;
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
@@ -8,7 +8,10 @@ import lombok.Getter;
 public class CommonTrans extends BaseEntity {
 
   private String title;
+
   private String content;
+
   private String address;
+
   private String time;
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
@@ -1,0 +1,14 @@
+package com.jeju.nanaland.domain.common.entity;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public class CommonTrans extends BaseEntity {
+
+  private String title;
+  private String content;
+  private String address;
+  private String time;
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Language.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Language.java
@@ -1,0 +1,21 @@
+package com.jeju.nanaland.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Language extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String locale;
+
+  @Column(nullable = false)
+  private String dateFormat;
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
@@ -1,0 +1,20 @@
+package com.jeju.nanaland.domain.experience.entity;
+
+import com.jeju.nanaland.domain.common.entity.Common;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Experience extends Common {
+
+  private String rating;
+
+  @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<ExperienceTrans> experienceTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
@@ -1,0 +1,30 @@
+package com.jeju.nanaland.domain.experience.entity;
+
+import com.jeju.nanaland.domain.common.entity.CommonTrans;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ExperienceTrans extends CommonTrans {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Experience experience;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String intro;
+
+  private String details;
+
+  private String amenity;
+}

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -1,0 +1,20 @@
+package com.jeju.nanaland.domain.festival.entity;
+
+import com.jeju.nanaland.domain.common.entity.Common;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Festival extends Common {
+
+  private String homepage;
+
+  @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<FestivalTrans> festivalTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.festival.entity;
+
+import com.jeju.nanaland.domain.common.entity.CommonTrans;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FestivalTrans extends CommonTrans {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Festival festival;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String price;
+}

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
@@ -1,0 +1,20 @@
+package com.jeju.nanaland.domain.market.entity;
+
+import com.jeju.nanaland.domain.common.entity.Common;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Market extends Common {
+
+  private String homepage;
+
+  @OneToMany(mappedBy = "market", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<MarketTrans> marketTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.market.entity;
+
+import com.jeju.nanaland.domain.common.entity.CommonTrans;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MarketTrans extends CommonTrans {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Market market;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String amenity;
+}

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -1,0 +1,19 @@
+package com.jeju.nanaland.domain.nana.entity;
+
+import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Nana extends BaseEntity {
+
+  String imageUrl;
+
+  @OneToMany(mappedBy = "nana")
+  private List<NanaTrans> nanaTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.domain.nana.entity;
 
 import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
@@ -14,6 +15,6 @@ public class Nana extends BaseEntity {
 
   String imageUrl;
 
-  @OneToMany(mappedBy = "nana")
+  @OneToMany(mappedBy = "nana", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<NanaTrans> nanaTrans;
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.nana.entity;
+
+import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class NanaTrans extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Nana nana;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String content;
+}

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
@@ -1,0 +1,18 @@
+package com.jeju.nanaland.domain.nature.entity;
+
+import com.jeju.nanaland.domain.common.entity.Common;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Nature extends Common {
+
+  @OneToMany(mappedBy = "nature", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<NatureTrans> natureTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
@@ -1,0 +1,30 @@
+package com.jeju.nanaland.domain.nature.entity;
+
+import com.jeju.nanaland.domain.common.entity.CommonTrans;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class NatureTrans extends CommonTrans {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Nature nature;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String intro;
+
+  private String details;
+
+  private String amenity;
+}

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -1,0 +1,27 @@
+package com.jeju.nanaland.domain.stay.entity;
+
+import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import com.jeju.nanaland.domain.common.entity.Common;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Stay extends Common {
+
+  private Integer price;
+
+  private String homepage;
+
+  private String parking;
+
+  private Integer rating;
+
+  @OneToMany(mappedBy = "stay", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  private List<StayTrans> stayTrans;
+}

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
@@ -1,0 +1,35 @@
+package com.jeju.nanaland.domain.stay.entity;
+
+import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import com.jeju.nanaland.domain.common.entity.CommonTrans;
+import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class StayTrans extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Stay stay;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Language language;
+
+  private String title;
+
+  private String intro;
+
+  private String price;
+
+  private String address;
+
+  private String time;
+}


### PR DESCRIPTION
## 📝 Description
- common > entity 에 BaseEntity를 상속받는 Common, CommonTrans 엔티티 추가
- Nana, NanaTrans 엔티티 추가
- 6대 카테고리 엔티티 추가
- querydsl 의존성 추가
- DB의존성 추가 (main - mariadb, test - H2)
- common > config 에 QuerydslConfig 설정 파일 추가

<br>

## 💬 To Reviewers
- [x] 아직 로컬에서 돌려서 상관은 없지만 백엔드 application.yml에 main과 test에서 사용할 application.yml 올려뒀습니다. 

<br>

## ☑️ Related Issue
stay는 common을 상속받고 stayTrans는 baseEntity를 상속받는데 괜찮을까요?
