### PR TITLE
[Feat] 엔티티 형식 통일, 긴 문자열 데이터 타입 변경, 빌더 테스트코드

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class Common extends BaseEntity {
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String imageUrl;
 
   private String contact;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -1,5 +1,6 @@
 package com.jeju.nanaland.domain.common.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,10 +9,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @MappedSuperclass
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class Common extends BaseEntity {
 
+  @Column(columnDefinition = "TEXT")
   private String imageUrl;
 
   private String contact;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Common.java
@@ -1,11 +1,16 @@
 package com.jeju.nanaland.domain.common.entity;
 
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @MappedSuperclass
-public class Common extends BaseEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public abstract class Common extends BaseEntity {
 
   private String imageUrl;
 

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
@@ -1,5 +1,6 @@
 package com.jeju.nanaland.domain.common.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,14 +9,16 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @MappedSuperclass
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class CommonTrans extends BaseEntity {
 
   private String title;
 
+  @Column(columnDefinition = "TEXT")
   private String content;
 
+  @Column(columnDefinition = "TEXT")
   private String address;
 
   private String time;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
@@ -18,7 +18,7 @@ public abstract class CommonTrans extends BaseEntity {
   @Column(columnDefinition = "TEXT")
   private String content;
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String address;
 
   private String time;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/CommonTrans.java
@@ -1,11 +1,16 @@
 package com.jeju.nanaland.domain.common.entity;
 
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @MappedSuperclass
-public class CommonTrans extends BaseEntity {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public abstract class CommonTrans extends BaseEntity {
 
   private String title;
 

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
@@ -4,6 +4,7 @@ import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -15,14 +16,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Experience extends Common {
 
+  private String type;
+
   private Float rating;
 
   @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE)
   private List<ExperienceTrans> experienceTrans;
 
   @Builder
-  public Experience(String imageUrl, String contact, Float rating) {
+  public Experience(String imageUrl, String contact, String type, Float rating) {
     super(imageUrl, contact);
+    this.type = type;
     this.rating = rating;
+    this.experienceTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,4 +18,10 @@ public class Experience extends Common {
 
   @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<ExperienceTrans> experienceTrans;
+
+  @Builder
+  public Experience(String imageUrl, String contact, String rating) {
+    super(imageUrl, contact);
+    this.rating = rating;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
@@ -18,16 +18,16 @@ public class Experience extends Common {
 
   private String type;
 
-  private Float rating;
+  private Float ratingAvg;
 
   @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE)
   private List<ExperienceTrans> experienceTrans;
 
   @Builder
-  public Experience(String imageUrl, String contact, String type, Float rating) {
+  public Experience(String imageUrl, String contact, String type, Float ratingAvg) {
     super(imageUrl, contact);
     this.type = type;
-    this.rating = rating;
+    this.ratingAvg = ratingAvg;
     this.experienceTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/Experience.java
@@ -5,22 +5,23 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Experience extends Common {
 
-  private String rating;
+  private Float rating;
 
-  @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "experience", cascade = CascadeType.REMOVE)
   private List<ExperienceTrans> experienceTrans;
 
   @Builder
-  public Experience(String imageUrl, String contact, String rating) {
+  public Experience(String imageUrl, String contact, Float rating) {
     super(imageUrl, contact);
     this.rating = rating;
   }

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,13 @@ public class ExperienceTrans extends CommonTrans {
   private String details;
 
   private String amenity;
+
+  @Builder
+  public ExperienceTrans(String title, String content, String address, String time, String intro,
+      String details, String amenity) {
+    super(title, content, address, time);
+    this.intro = intro;
+    this.details = details;
+    this.amenity = amenity;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
@@ -31,9 +31,12 @@ public class ExperienceTrans extends CommonTrans {
   private String amenity;
 
   @Builder
-  public ExperienceTrans(String title, String content, String address, String time, String intro,
+  public ExperienceTrans(Experience experience, Language language, String title, String content,
+      String address, String time, String intro,
       String details, String amenity) {
     super(title, content, address, time);
+    this.experience = experience;
+    this.language = language;
     this.intro = intro;
     this.details = details;
     this.amenity = amenity;

--- a/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/entity/ExperienceTrans.java
@@ -6,21 +6,22 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExperienceTrans extends CommonTrans {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "experience_id", nullable = false)
   private Experience experience;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
   private String intro;

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -2,21 +2,24 @@ package com.jeju.nanaland.domain.festival.entity;
 
 import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Festival extends Common {
 
+  @Column(columnDefinition = "TEXT")
   private String homepage;
 
-  @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE)
   private List<FestivalTrans> festivalTrans;
 
   @Builder

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Festival extends Common {
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String homepage;
 
   @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE)

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -5,16 +5,23 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class Festival extends Common {
 
   private String homepage;
 
   @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<FestivalTrans> festivalTrans;
+
+  @Builder
+  public Festival(String imageUrl, String contact, String homepage) {
+    super(imageUrl, contact);
+    this.homepage = homepage;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,5 +27,6 @@ public class Festival extends Common {
   public Festival(String imageUrl, String contact, String homepage) {
     super(imageUrl, contact);
     this.homepage = homepage;
+    this.festivalTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class FestivalTrans extends CommonTrans {
   private Language language;
 
   private String price;
+
+  @Builder
+  public FestivalTrans(String title, String content, String address, String time, String price) {
+    super(title, content, address, time);
+    this.price = price;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
@@ -6,28 +6,29 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FestivalTrans extends CommonTrans {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "festival_id", nullable = false)
   private Festival festival;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
-  private String price;
+  private String fee;
 
   @Builder
-  public FestivalTrans(String title, String content, String address, String time, String price) {
+  public FestivalTrans(String title, String content, String address, String time, String fee) {
     super(title, content, address, time);
-    this.price = price;
+    this.fee = fee;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
@@ -27,8 +27,11 @@ public class FestivalTrans extends CommonTrans {
   private String fee;
 
   @Builder
-  public FestivalTrans(String title, String content, String address, String time, String fee) {
+  public FestivalTrans(Festival festival, Language language, String title, String content,
+      String address, String time, String fee) {
     super(title, content, address, time);
+    this.festival = festival;
+    this.language = language;
     this.fee = fee;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,4 +18,10 @@ public class Market extends Common {
 
   @OneToMany(mappedBy = "market", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<MarketTrans> marketTrans;
+
+  @Builder
+  public Market(String imageUrl, String contact, String homepage) {
+    super(imageUrl, contact);
+    this.homepage = homepage;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,5 +27,6 @@ public class Market extends Common {
   public Market(String imageUrl, String contact, String homepage) {
     super(imageUrl, contact);
     this.homepage = homepage;
+    this.marketTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
@@ -2,21 +2,24 @@ package com.jeju.nanaland.domain.market.entity;
 
 import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Market extends Common {
 
+  @Column(columnDefinition = "TEXT")
   private String homepage;
 
-  @OneToMany(mappedBy = "market", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "market", cascade = CascadeType.REMOVE)
   private List<MarketTrans> marketTrans;
 
   @Builder

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/Market.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Market extends Common {
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String homepage;
 
   @OneToMany(mappedBy = "market", cascade = CascadeType.REMOVE)

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class MarketTrans extends CommonTrans {
   private Language language;
 
   private String amenity;
+
+  @Builder
+  public MarketTrans(String title, String content, String address, String time, String amenity) {
+    super(title, content, address, time);
+    this.amenity = amenity;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
@@ -27,8 +27,11 @@ public class MarketTrans extends CommonTrans {
   private String amenity;
 
   @Builder
-  public MarketTrans(String title, String content, String address, String time, String amenity) {
+  public MarketTrans(Market market, Language language, String title, String content, String address,
+      String time, String amenity) {
     super(title, content, address, time);
+    this.market = market;
+    this.language = language;
     this.amenity = amenity;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/entity/MarketTrans.java
@@ -6,21 +6,22 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MarketTrans extends CommonTrans {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "market_id", nullable = false)
   private Market market;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
   private String amenity;

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -5,12 +5,16 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Nana extends BaseEntity {
 
   String imageUrl;

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -2,9 +2,11 @@ package com.jeju.nanaland.domain.nana.entity;
 
 import com.jeju.nanaland.domain.common.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +15,13 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Nana extends BaseEntity {
 
+  @Column(columnDefinition = "TEXT")
   String imageUrl;
 
-  @OneToMany(mappedBy = "nana", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "nana", cascade = CascadeType.REMOVE)
   private List<NanaTrans> nanaTrans;
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -5,17 +5,15 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Nana extends BaseEntity {
 
@@ -24,4 +22,10 @@ public class Nana extends BaseEntity {
 
   @OneToMany(mappedBy = "nana", cascade = CascadeType.REMOVE)
   private List<NanaTrans> nanaTrans;
+
+  @Builder
+  public Nana(String imageUrl) {
+    this.imageUrl = imageUrl;
+    this.nanaTrans = new ArrayList<>();
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/Nana.java
@@ -19,8 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Nana extends BaseEntity {
 
-  @Column(columnDefinition = "TEXT")
-  String imageUrl;
+  @Column(columnDefinition = "VARCHAR(2048)")
+  private String imageUrl;
 
   @OneToMany(mappedBy = "nana", cascade = CascadeType.REMOVE)
   private List<NanaTrans> nanaTrans;

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
@@ -2,10 +2,12 @@ package com.jeju.nanaland.domain.nana.entity;
 
 import com.jeju.nanaland.domain.common.entity.BaseEntity;
 import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +16,18 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NanaTrans extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "nana_id", nullable = false)
   private Nana nana;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
+  @Column(columnDefinition = "TEXT")
   private String content;
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/entity/NanaTrans.java
@@ -6,12 +6,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class NanaTrans extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,4 +16,9 @@ public class Nature extends Common {
 
   @OneToMany(mappedBy = "nature", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<NatureTrans> natureTrans;
+
+  @Builder
+  public Nature(String imageUrl, String contact) {
+    super(imageUrl, contact);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
@@ -4,6 +4,7 @@ import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,5 +22,6 @@ public class Nature extends Common {
   @Builder
   public Nature(String imageUrl, String contact) {
     super(imageUrl, contact);
+    this.natureTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/Nature.java
@@ -5,16 +5,17 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Nature extends Common {
 
-  @OneToMany(mappedBy = "nature", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "nature", cascade = CascadeType.REMOVE)
   private List<NatureTrans> natureTrans;
 
   @Builder

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
@@ -6,21 +6,22 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NatureTrans extends CommonTrans {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "nature_id", nullable = false)
   private Nature nature;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
   private String intro;

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,13 @@ public class NatureTrans extends CommonTrans {
   private String details;
 
   private String amenity;
+
+  @Builder
+  public NatureTrans(String title, String content, String address, String time, String intro,
+      String details, String amenity) {
+    super(title, content, address, time);
+    this.intro = intro;
+    this.details = details;
+    this.amenity = amenity;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/entity/NatureTrans.java
@@ -31,9 +31,12 @@ public class NatureTrans extends CommonTrans {
   private String amenity;
 
   @Builder
-  public NatureTrans(String title, String content, String address, String time, String intro,
+  public NatureTrans(Nature nature, Language language, String title, String content, String address,
+      String time, String intro,
       String details, String amenity) {
     super(title, content, address, time);
+    this.nature = nature;
+    this.language = language;
     this.intro = intro;
     this.details = details;
     this.amenity = amenity;

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -19,7 +19,7 @@ public class Stay extends Common {
 
   private Integer price;
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String homepage;
 
   private String parking;

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -24,19 +24,19 @@ public class Stay extends Common {
 
   private String parking;
 
-  private Float rating;
+  private Float ratingAvg;
 
   @OneToMany(mappedBy = "stay", cascade = CascadeType.REMOVE)
   private List<StayTrans> stayTrans;
 
   @Builder
   public Stay(String imageUrl, String contact, Integer price, String homepage, String parking,
-      Float rating) {
+      Float ratingAvg) {
     super(imageUrl, contact);
     this.price = price;
     this.homepage = homepage;
     this.parking = parking;
-    this.rating = rating;
+    this.ratingAvg = ratingAvg;
     this.stayTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -1,11 +1,11 @@
 package com.jeju.nanaland.domain.stay.entity;
 
-import com.jeju.nanaland.domain.common.entity.BaseEntity;
 import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +24,14 @@ public class Stay extends Common {
 
   @OneToMany(mappedBy = "stay", cascade = CascadeType.REMOVE, orphanRemoval = true)
   private List<StayTrans> stayTrans;
+
+  @Builder
+  public Stay(String imageUrl, String contact, Integer price, String homepage, String parking,
+      Integer rating) {
+    super(imageUrl, contact);
+    this.price = price;
+    this.homepage = homepage;
+    this.parking = parking;
+    this.rating = rating;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -2,32 +2,35 @@ package com.jeju.nanaland.domain.stay.entity;
 
 import com.jeju.nanaland.domain.common.entity.Common;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stay extends Common {
 
   private Integer price;
 
+  @Column(columnDefinition = "TEXT")
   private String homepage;
 
   private String parking;
 
-  private Integer rating;
+  private Float rating;
 
-  @OneToMany(mappedBy = "stay", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "stay", cascade = CascadeType.REMOVE)
   private List<StayTrans> stayTrans;
 
   @Builder
   public Stay(String imageUrl, String contact, Integer price, String homepage, String parking,
-      Integer rating) {
+      Float rating) {
     super(imageUrl, contact);
     this.price = price;
     this.homepage = homepage;

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/Stay.java
@@ -5,6 +5,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -36,5 +37,6 @@ public class Stay extends Common {
     this.homepage = homepage;
     this.parking = parking;
     this.rating = rating;
+    this.stayTrans = new ArrayList<>();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
@@ -1,18 +1,21 @@
 package com.jeju.nanaland.domain.stay.entity;
 
 import com.jeju.nanaland.domain.common.entity.BaseEntity;
-import com.jeju.nanaland.domain.common.entity.CommonTrans;
 import com.jeju.nanaland.domain.common.entity.Language;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class StayTrans extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
@@ -32,7 +32,7 @@ public class StayTrans extends BaseEntity {
 
   private String intro;
 
-  @Column(columnDefinition = "TEXT")
+  @Column(columnDefinition = "VARCHAR(2048)")
   private String address;
 
   private String time;

--- a/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/stay/entity/StayTrans.java
@@ -2,10 +2,12 @@ package com.jeju.nanaland.domain.stay.entity;
 
 import com.jeju.nanaland.domain.common.entity.BaseEntity;
 import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,24 +16,23 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StayTrans extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "stay_id", nullable = false)
   private Stay stay;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 
   private String title;
 
   private String intro;
 
-  private String price;
-
+  @Column(columnDefinition = "TEXT")
   private String address;
 
   private String time;

--- a/src/test/java/com/jeju/nanaland/domain/entity/EntityBuilderTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/entity/EntityBuilderTest.java
@@ -1,0 +1,167 @@
+package com.jeju.nanaland.domain.entity;
+
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.experience.entity.Experience;
+import com.jeju.nanaland.domain.experience.entity.ExperienceTrans;
+import com.jeju.nanaland.domain.festival.entity.Festival;
+import com.jeju.nanaland.domain.festival.entity.FestivalTrans;
+import com.jeju.nanaland.domain.market.entity.Market;
+import com.jeju.nanaland.domain.market.entity.MarketTrans;
+import com.jeju.nanaland.domain.nana.entity.Nana;
+import com.jeju.nanaland.domain.nana.entity.NanaTrans;
+import com.jeju.nanaland.domain.nature.entity.Nature;
+import com.jeju.nanaland.domain.nature.entity.NatureTrans;
+import com.jeju.nanaland.domain.stay.entity.Stay;
+import com.jeju.nanaland.domain.stay.entity.StayTrans;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class EntityBuilderTest {
+
+  @Autowired
+  EntityManager em;
+
+  Language language;
+
+  @BeforeEach
+  void init() {
+    language = Language.builder()
+        .locale("kr")
+        .dateFormat("yyyy-mm-dd")
+        .build();
+
+    em.persist(language);
+  }
+
+  @Test
+  void NanaBuilderTest() {
+    Nana nana1 = Nana.builder()
+        .imageUrl("imageUrl")
+        .build();
+    em.persist(nana1);
+
+    NanaTrans nanaTrans1 = NanaTrans.builder()
+        .nana(nana1)
+        .language(language)
+        .content("content")
+        .build();
+    em.persist(nanaTrans1);
+  }
+
+  @Test
+  void stayBuilderTest() {
+    Stay stay1 = Stay.builder()
+        .imageUrl("imageUrl")
+        .price(12345)
+        .contact("0101231242")
+        .homepage("httpsL//egegwgeg")
+        .parking("allow?")
+        .ratingAvg(4.15f)
+        .build();
+    em.persist(stay1);
+
+    StayTrans stayTrans1 = StayTrans.builder()
+        .stay(stay1)
+        .language(language)
+        .title("title")
+        .intro("intro")
+        .address("address")
+        .time("10:00 ~ 12:00")
+        .build();
+    em.persist(stayTrans1);
+  }
+
+  @Test
+  void marketBuilderTest() {
+    Market market1 = Market.builder()
+        .imageUrl("imageUrl")
+        .contact("01023244124")
+        .homepage("homepageUrl")
+        .build();
+    em.persist(market1);
+
+    MarketTrans marketTrans1 = MarketTrans.builder()
+        .market(market1)
+        .language(language)
+        .title("title")
+        .content("content")
+        .address("address")
+        .time("time")
+        .amenity("amenity")
+        .build();
+    em.persist(marketTrans1);
+  }
+
+  @Test
+  void festivalBuilderTest() {
+    Festival festival1 = Festival.builder()
+        .imageUrl("imageUrl")
+        .contact("contact")
+        .homepage("homepage")
+        .build();
+    em.persist(festival1);
+
+    FestivalTrans festivalTrans1 = FestivalTrans.builder()
+        .festival(festival1)
+        .language(language)
+        .title("title")
+        .content("content")
+        .address("address")
+        .time("time")
+        .fee("fee")
+        .build();
+    em.persist(festivalTrans1);
+  }
+
+  @Test
+  void natureBuilderTest() {
+    Nature nature1 = Nature.builder()
+        .imageUrl("imageUrl")
+        .contact("contact")
+        .build();
+    em.persist(nature1);
+
+    NatureTrans natureTrans1 = NatureTrans.builder()
+        .nature(nature1)
+        .language(language)
+        .title("title")
+        .content("content")
+        .address("address")
+        .intro("intro")
+        .details("details")
+        .time("time")
+        .amenity("amenity")
+        .build();
+    em.persist(natureTrans1);
+  }
+
+  @Test
+  void experienceBuilderTest() {
+    Experience experience1 = Experience.builder()
+        .imageUrl("imageUrl")
+        .contact("contact")
+        .type("type")
+        .ratingAvg(4.24f)
+        .build();
+    em.persist(experience1);
+
+    ExperienceTrans experienceTrans1 = ExperienceTrans.builder()
+        .experience(experience1)
+        .language(language)
+        .title("title")
+        .content("content")
+        .address("address")
+        .intro("intro")
+        .details("details")
+        .time("time")
+        .amenity("amenity")
+        .build();
+    em.persist(experienceTrans1);
+  }
+}


### PR DESCRIPTION
## 📝 Description
- @NoArgsConstructor에 `access = AccessLevel.PROTECTED` 추가
- @JoinColumn에 `name, nullable` 추가
- `@Column(columnDefinition = "TEXT")`로 데이터 타입 변경
  - `CommonTrans`의 content, address
  - `NanaTrans`의 content
- `@Column(columnDefinition = "VARCHAR(2048)")`로 데이터 타입 변경
  - `CommonTrans`의 address
  - `StayTrans`의 address
  - `Nana`의 imageUrl
  - `Common`의 imageUrl
  - `Festival`의 homepage
  - `Market`의 homepage
  - `Stay`의 homepage
- 매핑관계 `orphanRemoval = true` 삭제
- 빌더패턴 테스트코드

<br>

## 💬 To Reviewers

<br>

## ☑️ Related Issue
