### PR TITLE
Feat/#16 s3 image upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // s3 image upload
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    
+
     // mariadb for server database
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     // h2 database for test
@@ -40,6 +40,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // s3 image upload
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     // s3 image upload
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.20'
 
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepository.java
@@ -1,0 +1,8 @@
+package com.jeju.nanaland.domain.common.repository;
+
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+
+}

--- a/src/main/java/com/jeju/nanaland/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ControllerAdvice.java
@@ -35,6 +35,14 @@ public class ControllerAdvice {
     return ApiResponse.error(ErrorCode.EXPIRED_TOKEN, e.getMessage());
   }
 
+  //415에러 (파일 확장자 오류)
+  @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+  @ExceptionHandler(UnsupportedFileFormatException.class)
+  public ApiResponse<String> handleUnsupportedFileFormatException(
+      UnsupportedFileFormatException e) {
+    return ApiResponse.error(ErrorCode.UNSUPPORTED_FILE_FORMAT, e.getMessage());
+  }
+
   private String makeErrorResponse(BindingResult bindingResult) {
     String description = "";
 

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,8 @@ public enum ErrorCode {
   BAD_REQUEST_EXCEPTION(BAD_REQUEST, "잘못된 요청입니다."),
   REQUEST_VALIDATION_EXCEPTION(BAD_REQUEST, "입력 형태가 잘못된 요청입니다."),
   UNAUTHORIZED_USER(UNAUTHORIZED, "access token이 존재하지 않습니다."),
-  EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰입니다.");
+  EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰입니다."),
+  UNSUPPORTED_FILE_FORMAT(UNSUPPORTED_MEDIA_TYPE, "적절하지 않은 확장자의 파일입니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/jeju/nanaland/global/exception/UnsupportedFileFormatException.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/UnsupportedFileFormatException.java
@@ -1,0 +1,13 @@
+package com.jeju.nanaland.global.exception;
+
+public class UnsupportedFileFormatException extends RuntimeException {
+
+  public UnsupportedFileFormatException() {
+    super(ErrorCode.UNSUPPORTED_FILE_FORMAT.getMessage());
+  }
+
+  public UnsupportedFileFormatException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
+++ b/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
@@ -4,11 +4,14 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImageService {
@@ -35,39 +38,28 @@ public class ImageService {
 
   @Transactional
   public String saveImage(MultipartFile multipartFile) {
-    String originalName = multipartFile.getOriginalFilename();
+    //uuid_originalFilename 로 s3에 업로드할 파일 이름 설정
+    UUID uuid = UUID.randomUUID();
+    String uploadImageName = uuid + "_" + multipartFile.getOriginalFilename();
+
     try {
       ObjectMetadata objectMetadata = new ObjectMetadata();
       objectMetadata.setContentType(multipartFile.getContentType());
       objectMetadata.setContentLength(multipartFile.getInputStream().available());
 
-      amazonS3Client.putObject(bucketName + imageDirectory, originalName,
+      //S3에 사진 올리기
+      amazonS3Client.putObject(bucketName + imageDirectory, uploadImageName,
           multipartFile.getInputStream(),
           objectMetadata);
 
-      String accessUrl = amazonS3Client.getUrl(bucketName + imageDirectory, originalName)
-          .toString();
-      return accessUrl;
+      //사진 저장 경로 받기
+
     } catch (IOException e) {
 
     }
-    return null;
-//    Image image = new Image(originalName);
-//    String filename = image.getStoredName();
-
-//    try {
-//      ObjectMetadata objectMetadata = new ObjectMetadata();
-//      objectMetadata.setContentType(multipartFile.getContentType());
-//      objectMetadata.setContentLength(multipartFile.getInputStream().available());
-//
-//      amazonS3Client.putObject(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
-//
-//      String accessUrl = amazonS3Client.getUrl(bucketName, filename).toString();
-//      image.setAccessUrl(accessUrl);
-//    } catch(IOException e) {
-//
-//    }
-//
+    String accessUrl = amazonS3Client.getUrl(bucketName + imageDirectory, uploadImageName)
+        .toString();
+    return accessUrl;
 //    imageRepository.save(image);
 //
 //    return image.getAccessUrl();

--- a/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
+++ b/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
@@ -1,0 +1,81 @@
+package com.jeju.nanaland.global.imageUpload;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private final AmazonS3Client amazonS3Client;
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucketName;
+
+  // 원본 사진 저장
+  @Value("/images")
+  private String imageDirectory;
+
+//  @Transactional
+//  public List<String> saveImages(ImageSaveDto saveDto) {
+//    List<String> resultList = new ArrayList<>();
+//
+//    for(MultipartFile multipartFile : saveDto.getImages()) {
+//      String value = saveImage(multipartFile);
+//      resultList.add(value);
+//    }
+//
+//    return resultList;
+//  }
+
+  @Transactional
+  public String saveImage(MultipartFile multipartFile) {
+    String originalName = multipartFile.getOriginalFilename();
+    try {
+      ObjectMetadata objectMetadata = new ObjectMetadata();
+      objectMetadata.setContentType(multipartFile.getContentType());
+      objectMetadata.setContentLength(multipartFile.getInputStream().available());
+
+      amazonS3Client.putObject(bucketName + imageDirectory, originalName,
+          multipartFile.getInputStream(),
+          objectMetadata);
+
+      String accessUrl = amazonS3Client.getUrl(bucketName + imageDirectory, originalName)
+          .toString();
+      return accessUrl;
+    } catch (IOException e) {
+
+    }
+    return null;
+//    Image image = new Image(originalName);
+//    String filename = image.getStoredName();
+
+//    try {
+//      ObjectMetadata objectMetadata = new ObjectMetadata();
+//      objectMetadata.setContentType(multipartFile.getContentType());
+//      objectMetadata.setContentLength(multipartFile.getInputStream().available());
+//
+//      amazonS3Client.putObject(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
+//
+//      String accessUrl = amazonS3Client.getUrl(bucketName, filename).toString();
+//      image.setAccessUrl(accessUrl);
+//    } catch(IOException e) {
+//
+//    }
+//
+//    imageRepository.save(image);
+//
+//    return image.getAccessUrl();
+//  }
+  }
+
+  @Transactional
+  public void deleteImage(String filename) {
+    amazonS3Client.deleteObject(bucketName, filename);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
+++ b/src/main/java/com/jeju/nanaland/global/imageUpload/ImageService.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.global.imageUpload;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.jeju.nanaland.global.exception.UnsupportedFileFormatException;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.UUID;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -24,6 +26,15 @@ public class ImageService {
   @Value("/images")
   private String imageDirectory;
 
+  public void verifyExtension(MultipartFile multipartFile) throws UnsupportedFileFormatException {
+    String contentType = multipartFile.getContentType();
+
+    // 확장자가 jpeg, png인 파일들만 받아서 처리
+    if (ObjectUtils.isEmpty(contentType) | (!contentType.contains("image/jpeg")
+        & !contentType.contains("image/png"))) {
+      throw new UnsupportedFileFormatException();
+    }
+  }
 //  @Transactional
 //  public List<String> saveImages(ImageSaveDto saveDto) {
 //    List<String> resultList = new ArrayList<>();
@@ -38,6 +49,10 @@ public class ImageService {
 
   @Transactional
   public String saveImage(MultipartFile multipartFile) {
+
+    //이미지 파일인지 검증
+    verifyExtension(multipartFile);
+
     //uuid_originalFilename 로 s3에 업로드할 파일 이름 설정
     UUID uuid = UUID.randomUUID();
     String uploadImageName = uuid + "_" + multipartFile.getOriginalFilename();
@@ -68,6 +83,8 @@ public class ImageService {
 
   @Transactional
   public void deleteImage(String filename) {
-    amazonS3Client.deleteObject(bucketName, filename);
+    // imageDirectory는 원본 image파일만 삭제하는 것
+    // 실제로 사용할 때는 thumbnail image도 삭제하는 로직 작성해야함.
+    amazonS3Client.deleteObject(bucketName + imageDirectory, filename);
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/imageUpload/S3Config.java
+++ b/src/main/java/com/jeju/nanaland/global/imageUpload/S3Config.java
@@ -22,8 +22,6 @@ public class S3Config {
 
   @Bean
   public AmazonS3Client amazonS3Client() {
-    log.info("accesskey=>{}", accessKey);
-    log.info("secertkey=>{}", secretKey);
     BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
     return (AmazonS3Client) AmazonS3ClientBuilder.standard()
         .withRegion(region)

--- a/src/main/java/com/jeju/nanaland/global/imageUpload/S3Config.java
+++ b/src/main/java/com/jeju/nanaland/global/imageUpload/S3Config.java
@@ -1,0 +1,33 @@
+package com.jeju.nanaland.global.imageUpload;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+  @Value("${cloud.aws.credentials.accessKey}")
+  private String accessKey;
+  @Value("${cloud.aws.credentials.secretKey}")
+  private String secretKey;
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3Client amazonS3Client() {
+    log.info("accesskey=>{}", accessKey);
+    log.info("secertkey=>{}", secretKey);
+    BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+        .withRegion(region)
+        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+        .build();
+  }
+}


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- s3 이미지 업로드
- 단일 이미지, 다중 이미지 업로드
- 이미지 삭제 (삭제는 단일 삭제 메서드만 존재)
- 확장자 검사, url에서 file name 추출, uuid로 파일 이름 변경

<br>

## 💬 To Reviewers
- [ ] 다중 이미지 업로드 할 때 dto 형태에 따라 uploadImages 의 매개변수 변경 하면 될 것 같습니다.
- [ ] aws람다 vs java Thumbnails 선택해서 썸네일 만드는 방식 고를 수 있었는데 우선 java 라이브러리로 처리했습니다. (람다 하다가 오류가 나기도 했고 아직 굳이 aws lambda를 써야하는 이유를 못찾겠습니다. 커뮤에 질문도 했는데 무참히 읽씹 당했습니다 허허)
- [ ] 썸네일 비율은 임의로 설정했습니다. 다른 파트분들과 얘기를 해봐야할 것 같습니다.


<br>

## ☑️ Related Issue
> 파일 다중 삭제는 story, review에서 작업 상황보고 하는 것이 좋을 것 같아서 아직 구현하지 않았습니다.
