### PR TITLE
[Feat] Jwt 생성 및 검증 부분 수정, 커스텀 어노테이션 추가

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -31,8 +31,10 @@ public class MemberLoginService {
 
     Member member = getOrCreateMember(loginDto);
 
-    String accessToken = jwtProvider.getAccessToken(String.valueOf(member.getId()));
-    String refreshToken = jwtProvider.getRefreshToken(String.valueOf(member.getId()));
+    String accessToken = jwtProvider.getAccessToken(String.valueOf(member.getId()),
+        member.getRoleSet());
+    String refreshToken = jwtProvider.getRefreshToken(String.valueOf(member.getId()),
+        member.getRoleSet());
 
     return JwtDto.builder()
         .accessToken(accessToken)
@@ -102,6 +104,9 @@ public class MemberLoginService {
       throw new BadRequestException(ErrorCode.INVALID_TOKEN.getMessage());
     }
 
-    return jwtProvider.getAccessToken(memberId);
+    Member member = memberRepository.findById(Long.valueOf(memberId))
+        .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
+
+    return jwtProvider.getAccessToken(memberId, member.getRoleSet());
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -9,7 +9,7 @@ import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
 import com.jeju.nanaland.global.exception.BadRequestException;
 import com.jeju.nanaland.global.exception.ErrorCode;
-import com.jeju.nanaland.global.jwt.JwtProvider;
+import com.jeju.nanaland.global.jwt.JwtUtil;
 import com.jeju.nanaland.global.jwt.dto.JwtResponseDto.JwtDto;
 import java.util.Optional;
 import java.util.Random;
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberLoginService {
 
   private final MemberRepository memberRepository;
-  private final JwtProvider jwtProvider;
+  private final JwtUtil jwtUtil;
   private final LanguageRepository languageRepository;
   private final ImageFileRepository imageFileRepository;
 
@@ -31,9 +31,9 @@ public class MemberLoginService {
 
     Member member = getOrCreateMember(loginDto);
 
-    String accessToken = jwtProvider.getAccessToken(String.valueOf(member.getId()),
+    String accessToken = jwtUtil.getAccessToken(String.valueOf(member.getId()),
         member.getRoleSet());
-    String refreshToken = jwtProvider.getRefreshToken(String.valueOf(member.getId()),
+    String refreshToken = jwtUtil.getRefreshToken(String.valueOf(member.getId()),
         member.getRoleSet());
 
     return JwtDto.builder()
@@ -91,14 +91,14 @@ public class MemberLoginService {
   }
 
   public String reissue(String bearerRefreshToken) {
-    String refreshToken = jwtProvider.resolveToken(bearerRefreshToken);
+    String refreshToken = jwtUtil.resolveToken(bearerRefreshToken);
 
-    if (!jwtProvider.verifyRefreshToken(refreshToken)) {
+    if (!jwtUtil.verifyRefreshToken(refreshToken)) {
       throw new BadRequestException(ErrorCode.INVALID_TOKEN.getMessage());
     }
 
-    String memberId = jwtProvider.getMemberIdFromRefresh(refreshToken);
-    String savedRefreshToken = jwtProvider.findRefreshTokenById(memberId);
+    String memberId = jwtUtil.getMemberIdFromRefresh(refreshToken);
+    String savedRefreshToken = jwtUtil.findRefreshTokenById(memberId);
 
     if (!refreshToken.equals(savedRefreshToken)) {
       throw new BadRequestException(ErrorCode.INVALID_TOKEN.getMessage());
@@ -107,6 +107,6 @@ public class MemberLoginService {
     Member member = memberRepository.findById(Long.valueOf(memberId))
         .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
 
-    return jwtProvider.getAccessToken(memberId, member.getRoleSet());
+    return jwtUtil.getAccessToken(memberId, member.getRoleSet());
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/config/SecurityConfig.java
+++ b/src/main/java/com/jeju/nanaland/global/config/SecurityConfig.java
@@ -2,7 +2,7 @@ package com.jeju.nanaland.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jeju.nanaland.global.jwt.JWTAuthenticationFilter;
-import com.jeju.nanaland.global.jwt.JwtProvider;
+import com.jeju.nanaland.global.jwt.JwtUtil;
 import com.jeju.nanaland.global.jwt.handler.CustomAccessDeniedHandler;
 import com.jeju.nanaland.global.jwt.handler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final JwtProvider jwtProvider;
+  private final JwtUtil jwtUtil;
   private final ObjectMapper objectMapper;
 
   @Bean
@@ -51,7 +51,7 @@ public class SecurityConfig {
     http
         .addFilterBefore(
             new JWTAuthenticationFilter(authenticationConfiguration.getAuthenticationManager(),
-                jwtProvider),
+                jwtUtil),
             UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(exceptionHandling -> exceptionHandling
             .accessDeniedHandler(new CustomAccessDeniedHandler(objectMapper))

--- a/src/main/java/com/jeju/nanaland/global/config/WebConfig.java
+++ b/src/main/java/com/jeju/nanaland/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.jeju.nanaland.global.config;
+
+import com.jeju.nanaland.global.jwt.AuthMemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(authMemberArgumentResolver);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
@@ -18,7 +19,9 @@ public enum ErrorCode {
   EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰입니다."),
   UNSUPPORTED_FILE_FORMAT(UNSUPPORTED_MEDIA_TYPE, "적절하지 않은 확장자의 파일입니다."),
   ACCESS_DENIED(UNAUTHORIZED, "접근 권한이 없습니다."),
-  INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다.");
+  INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+
+  MEMBER_NOT_FOUND(NOT_FOUND, "존재하는 회원을 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/jeju/nanaland/global/jwt/AuthMember.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/AuthMember.java
@@ -1,0 +1,12 @@
+package com.jeju.nanaland.global.jwt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthMember {
+
+}

--- a/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
@@ -17,7 +17,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
-  private final JwtProvider jwtProvider;
+  private final JwtUtil jwtUtil;
   private final MemberRepository memberRepository;
 
   @Override
@@ -31,8 +31,8 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
   public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
     String bearerAccessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-    String accessToken = jwtProvider.resolveToken(bearerAccessToken);
-    String memberId = jwtProvider.getMemberIdFromAccess(accessToken);
+    String accessToken = jwtUtil.resolveToken(bearerAccessToken);
+    String memberId = jwtUtil.getMemberIdFromAccess(accessToken);
     return memberRepository.findById(Long.valueOf(memberId))
         .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
   }

--- a/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.jeju.nanaland.global.jwt;
+
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.repository.MemberRepository;
+import com.jeju.nanaland.global.exception.BadRequestException;
+import com.jeju.nanaland.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+  private final JwtProvider jwtProvider;
+  private final MemberRepository memberRepository;
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    boolean hasAnnotation = parameter.getParameterAnnotation(AuthMember.class) != null;
+    boolean hasMemberType = Member.class.isAssignableFrom(parameter.getParameterType());
+    return hasAnnotation && hasMemberType;
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    String bearerAccessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+    String accessToken = jwtProvider.resolveToken(bearerAccessToken);
+    String memberId = jwtProvider.getMemberIdFromAccess(accessToken);
+    return memberRepository.findById(Long.valueOf(memberId))
+        .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/jwt/JWTAuthenticationFilter.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/JWTAuthenticationFilter.java
@@ -17,13 +17,13 @@ import org.springframework.util.StringUtils;
 @Slf4j
 public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
 
-  private final JwtProvider jwtProvider;
+  private final JwtUtil jwtUtil;
 
   public JWTAuthenticationFilter(AuthenticationManager authenticationManager,
-      JwtProvider jwtProvider) {
+      JwtUtil jwtUtil) {
 
     super(authenticationManager);
-    this.jwtProvider = jwtProvider;
+    this.jwtUtil = jwtUtil;
   }
 
   @Override
@@ -31,10 +31,10 @@ public class JWTAuthenticationFilter extends BasicAuthenticationFilter {
       FilterChain chain) throws IOException, ServletException {
 
     String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
-    String token = jwtProvider.resolveToken(bearerToken);
+    String token = jwtUtil.resolveToken(bearerToken);
 
-    if (StringUtils.hasLength(token) && jwtProvider.verifyAccessToken(token)) {
-      Authentication authentication = jwtProvider.getAuthentication(token);
+    if (StringUtils.hasLength(token) && jwtUtil.verifyAccessToken(token)) {
+      Authentication authentication = jwtUtil.getAuthentication(token);
       SecurityContextHolder.getContext().setAuthentication(authentication);
     }
     chain.doFilter(request, response);

--- a/src/main/java/com/jeju/nanaland/global/jwt/JwtProvider.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/JwtProvider.java
@@ -1,10 +1,15 @@
 package com.jeju.nanaland.global.jwt;
 
+import com.jeju.nanaland.domain.member.entity.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +17,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -24,9 +30,9 @@ public class JwtProvider {
   private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
   private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
   private static final String REDIS_KEY = "REFRESH:";
+  private static final String AUTHORITIES_KEY = "auth";
   private final SecretKey secretKey;
   private final SecretKey secretKey2;
-  private final MemberDetailsService memberDetailsService;
   private final RedisTemplate<String, String> redisTemplate;
   @Value("${jwt.access.expiration}")
   private Long accessExpirationPeriod;
@@ -41,29 +47,35 @@ public class JwtProvider {
     return secretKey2;
   }
 
-  public String getAccessToken(String memberId) {
-    Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));
-
+  public String getAccessToken(String memberId, Set<Role> roleSet) {
+    Claims claims = Jwts.claims().setSubject(memberId);
+    String authorities = roleSet.stream()
+        .map(Enum::name)
+        .collect(Collectors.joining(","));
     Date now = new Date();
     Date expiration = new Date(now.getTime() + accessExpirationPeriod);
 
     return Jwts.builder()
         .setSubject(ACCESS_TOKEN_SUBJECT)
         .setClaims(claims)
+        .claim(AUTHORITIES_KEY, authorities)
         .setExpiration(expiration)
         .signWith(secretKey, SignatureAlgorithm.HS512)
         .compact();
   }
 
-  public String getRefreshToken(String memberId) {
+  public String getRefreshToken(String memberId, Set<Role> roleSet) {
     Claims claims = Jwts.claims().setSubject(memberId);
-
+    String authorities = roleSet.stream()
+        .map(Enum::name)
+        .collect(Collectors.joining(","));
     Date now = new Date();
     Date expiration = new Date(now.getTime() + refreshExpirationPeriod);
 
     String refreshToken = Jwts.builder()
         .setSubject(REFRESH_TOKEN_SUBJECT)
         .setClaims(claims)
+        .claim(AUTHORITIES_KEY, authorities)
         .setExpiration(expiration)
         .signWith(secretKey2, SignatureAlgorithm.HS512)
         .compact();
@@ -100,8 +112,18 @@ public class JwtProvider {
   }
 
   public Authentication getAuthentication(String token) {
-    UserDetails userDetails = memberDetailsService.loadUserByUsername(getMemberIdFromAccess(token));
-    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(getSecretKey())
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+    Collection<? extends GrantedAuthority> authorities =
+        Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+
+    return new UsernamePasswordAuthenticationToken(getMemberIdFromAccess(token), "",
+        authorities);
   }
 
   public String resolveToken(String bearerToken) {

--- a/src/main/java/com/jeju/nanaland/global/jwt/JwtUtil.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/JwtUtil.java
@@ -25,7 +25,7 @@ import org.springframework.util.StringUtils;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class JwtProvider {
+public class JwtUtil {
 
   private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
   private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- `Jwtprovider.getAuthentication()`에서 `UserDetailService.loadUserByUsername()`을 호출하는 부분을 삭제했습니다.
- 이 부분을 삭제하고 진행을 하기 위해선 Jwt에 authorities를 포함해야 했기에 Jwt 생성 함수도 일부 수정되었습니다.
- `@AuthMember`라는 커스텀 어노테이션을 생성하였습니다.

<br>

## 💬 To Reviewers
- [ ] `@AuthMember`는 헤더로 담겨온 JWT에서 memberId를 읽어오며, DB로부터 Member 객체를 가져옵니다.
- [ ] Postman에서 매번 로그인하여 토큰을 복붙하기 귀찮으시다면, 이 방법을 사용해보세요. 로그인 시에 자동으로 다른  API 헤더에 토큰이 담기게 됩니다. (편리해용)

1. environment 생성
![image](https://github.com/Travel-in-nanaland/Back-end/assets/73464584/93644df5-92bc-4cb8-8a6c-9668a8139061)

2. 맨 우측화면에서 environment 설정
![image](https://github.com/Travel-in-nanaland/Back-end/assets/73464584/8f481f48-765c-43da-af72-d5873876298c)

3. `/member/login` TEST 탭에 코드 추가
![image](https://github.com/Travel-in-nanaland/Back-end/assets/73464584/5a8f9a25-0fb1-45c6-b502-d9f0167cf96d)
 

```javascript
if(pm.response.code === 200) {
    var jsonData = pm.response.json();
    var accessToken = jsonData.data.accessToken;
    var refreshToken = jsonData.data.refreshToken;
    pm.environment.set('token', accessToken);
    pm.environment.set('refreshToken', refreshToken);
}
```

4. 다른 API에서 변수 설정해주기

![image](https://github.com/Travel-in-nanaland/Back-end/assets/73464584/76ec4fab-4c21-4520-9530-9e6ee88705a4)

![image](https://github.com/Travel-in-nanaland/Back-end/assets/73464584/15c2d155-ea22-41d2-a8ff-4fff5ac35b15)

이상입니다!!!

<br>

## ☑️ Related Issue
> close #27 
