### PR TITLE
[#30] feat: 인기 검색어 조회

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -108,5 +109,19 @@ public class SearchController {
     Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
         searchService.getMarketSearchResultDto(title, locale, pageable));
+  }
+
+  @Operation(
+      summary = "인기 검색어 조회",
+      description = "언어 별로 가장 검색이 많이 된 8개 반환")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
+  })
+  @GetMapping("/popular")
+  public BaseResponse<List<String>> getPopularSearch(@AuthMember Member member) {
+
+    Locale locale = member.getLanguage().getLocale();
+    return BaseResponse.success(SEARCH_SUCCESS, searchService.getPopularSearch(locale));
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -11,7 +11,6 @@ import com.jeju.nanaland.domain.nature.dto.NatureCompositeDto;
 import com.jeju.nanaland.domain.nature.repository.NatureRepository;
 import com.jeju.nanaland.domain.search.dto.SearchResponse;
 import com.jeju.nanaland.domain.search.dto.SearchResponse.ThumbnailDto;
-import com.jeju.nanaland.global.exception.ServerErrorException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -166,11 +165,6 @@ public class SearchService {
     String language = locale.name();
     String key = "ranking_" + language;
 
-    try {
-      redisTemplate.opsForZSet().incrementScore(key, title, 1);
-    } catch (Exception e) {
-      log.error("redis error {}", e.getMessage());
-      throw new ServerErrorException();
-    }
+    redisTemplate.opsForZSet().incrementScore(key, title, 1);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -37,6 +37,8 @@ public class SearchService {
   private final RedisTemplate<String, String> redisTemplate;
 
   public SearchResponse.CategoryDto getCategorySearchResultDto(String title, Locale locale) {
+    // Redis에 해당 검색어 count + 1
+    updateSearchCount(title, locale);
 
     // offset: 0, pageSize: 2
     Pageable pageable = PageRequest.of(0, 2);
@@ -73,8 +75,6 @@ public class SearchService {
 
   public SearchResponse.ResultDto getFestivalSearchResultDto(String title, Locale locale,
       Pageable pageable) {
-    // Redis에 해당 검색어 count + 1
-    updateSearchCount(title, locale);
 
     Page<FestivalCompositeDto> ResultDto = festivalRepository.searchCompositeDtoByTitle(title,
         locale,
@@ -160,6 +160,9 @@ public class SearchService {
   }
 
   private void updateSearchCount(String title, Locale locale) {
+    /**
+     * TODO: 시간별로 key를 구성하고 업데이트
+     */
     String language = locale.name();
     String key = "ranking_" + language;
 


### PR DESCRIPTION
## 📝 Description
- 언어 별로 인기 검색어 8개 조회

<br>

## 💬 To Reviewers
- 인기 검색어에 여러 언어가 있는게 부자연스럽다고 생각해서 우선 ranking_KOREAN, ranking_ENGLISH 등으로 key를 설정해서 언어별로 인기 검색어를 반환하게 구현했습니다.
- 시간 별로 인기 검색어를 어떻게 보여줘야 하나 고민하다가 우선 다음과 같은 방법으로 구현했습니다. 
![image](https://github.com/Travel-in-nanaland/Back-end/assets/98393795/80479030-1ea1-4961-96e3-82db4b5133f7)


 

<br>

## ☑️ Related Issue 
- close #30 
