### PR TITLE
[Feat] 로그인 회원 생성 로직 수정

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/annotation/EnumValidator.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/annotation/EnumValidator.java
@@ -3,6 +3,7 @@ package com.jeju.nanaland.domain.common.annotation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ObjectUtils;
 
 @Slf4j
 public class EnumValidator implements ConstraintValidator<EnumValid, String> {
@@ -24,7 +25,7 @@ public class EnumValidator implements ConstraintValidator<EnumValid, String> {
     // value로 들어온 값이 Enum에 존재하는지 확인
     if (enumValues != null) {
       for (Object enumValue : enumValues) {
-        if (value.equals(enumValue.toString()) ||
+        if (ObjectUtils.isNotEmpty(value) && value.equals(enumValue.toString()) ||
             this.enumValid.ignoreCase() && value.equalsIgnoreCase(enumValue.toString())) {
 
           ResultDto = true;

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Locale.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Locale.java
@@ -1,16 +1,5 @@
 package com.jeju.nanaland.domain.common.entity;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.stream.Stream;
-
 public enum Locale {
-  KOREAN, ENGLISH, CHINESE, MALAYSIA;
-
-  @JsonCreator
-  public static Locale parsing(String inputValue) {
-    return Stream.of(Locale.values())
-        .filter(locale -> locale.toString().equals(inputValue.toUpperCase()))
-        .findFirst()
-        .orElse(null);
-  }
+  KOREAN, ENGLISH, CHINESE, MALAYSIA
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -47,7 +47,8 @@ public class MemberController {
   @Operation(summary = "로그인", description = "로그인을 하면 JWT가 발급됩니다.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content)
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "409", description = "데이터가 중복되는 경우", content = @Content)
   })
   @PostMapping("/login")
   public BaseResponse<JwtDto> login(@RequestBody @Valid LoginDto loginDto) {

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -5,6 +5,7 @@ import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.member.entity.MemberType;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -20,10 +21,15 @@ public class MemberRequest {
     @Schema(description = "언어", example = "KOREAN",
         allowableValues = {"KOREAN", "ENGLISH", "CHINESE", "MALAYSIA"})
     @NotNull
-    private Locale locale;
+    @EnumValid(
+        enumClass = Locale.class,
+        message = "Locale이 유효하지 않습니다."
+    )
+    private String locale;
 
     @Schema(description = "이메일", example = "ABD123@kakao.com")
     @NotBlank
+    @Email(message = "이메일 형식에 맞지 않습니다.")
     private String email;
 
     @Schema(description = "성별", example = "male", allowableValues = {"male", "female"})
@@ -33,12 +39,15 @@ public class MemberRequest {
     private LocalDate birthDate;
 
     @Schema(description = "소셜 로그인 Provider", example = "KAKAO",
-        allowableValues = {"KAKAO", "GOOGLE"})
+        allowableValues = {"KAKAO", "GOOGLE", "APPLE"})
     @NotNull
-    private Provider provider;
+    @EnumValid(
+        enumClass = Provider.class,
+        message = "Provider이 유효하지 않습니다."
+    )
+    private String provider;
 
-    @Schema(description = "소셜 로그인 Provider ID", example = "1234567890",
-        allowableValues = {"KAKAO", "GOOGLE"})
+    @Schema(description = "소셜 로그인 Provider ID", example = "1234567890")
     @NotNull
     private Long providerId;
   }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/Provider.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/Provider.java
@@ -1,16 +1,5 @@
 package com.jeju.nanaland.domain.member.entity;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.stream.Stream;
-
 public enum Provider {
-  KAKAO, GOOGLE;
-
-  @JsonCreator
-  public static Provider parsing(String inputValue) {
-    return Stream.of(Provider.values())
-        .filter(provider -> provider.toString().equals(inputValue.toUpperCase()))
-        .findFirst()
-        .orElse(null);
-  }
+  KAKAO, GOOGLE, APPLE
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepository.java
@@ -9,8 +9,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-  Optional<Member> findByProviderAndProviderId(Provider provider, Long providerId);
-
+  Optional<Member> findByEmailAndProviderAndProviderId(String email, Provider provider,
+      Long providerId);
+  
   @Query("select m from Member m join fetch m.roleSet where m.id = :memberId")
   Optional<Member> findMemberById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.jeju.nanaland.domain.member.repository;
+
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import java.util.Optional;
+
+public interface MemberRepositoryCustom {
+
+  Optional<Member> findDuplicateMember(String email, Provider provider,
+      Long providerId);
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.member.repository;
+
+import static com.jeju.nanaland.domain.member.entity.QMember.member;
+
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<Member> findDuplicateMember(String email, Provider provider, Long providerId) {
+    return queryFactory
+        .selectFrom(member)
+        .where(member.email.eq(email)
+            .or(member.provider.eq(provider)
+                .and(member.providerId.eq(providerId))
+            ))
+        .stream().findAny();
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -2,10 +2,12 @@ package com.jeju.nanaland.domain.member.service;
 
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.common.repository.LanguageRepository;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
 import com.jeju.nanaland.domain.member.repository.MemberRepositoryCustom;
 import com.jeju.nanaland.global.exception.BadRequestException;
@@ -49,7 +51,7 @@ public class MemberLoginService {
   public Member getOrCreateMember(LoginDto loginDto) {
     Optional<Member> memberOptional = memberRepository.findByEmailAndProviderAndProviderId(
         loginDto.getEmail(),
-        loginDto.getProvider(),
+        Provider.valueOf(loginDto.getProvider()),
         loginDto.getProviderId());
 
     if (memberOptional.isEmpty()) {
@@ -64,14 +66,14 @@ public class MemberLoginService {
 
     Optional<Member> memberOptional = memberRepositoryCustom.findDuplicateMember(
         loginDto.getEmail(),
-        loginDto.getProvider(),
+        Provider.valueOf(loginDto.getProvider()),
         loginDto.getProviderId());
 
     if (memberOptional.isPresent()) {
       throw new ConflictException(ErrorCode.MEMBER_DUPLICATE.getMessage());
     }
 
-    Language language = languageRepository.findByLocale(loginDto.getLocale());
+    Language language = languageRepository.findByLocale(Locale.valueOf(loginDto.getLocale()));
 
     ImageFile profileImageFile = getRandomProfileImageFile();
 
@@ -84,7 +86,7 @@ public class MemberLoginService {
         .nickname(nickname)
         .gender(loginDto.getGender())
         .birthDate(loginDto.getBirthDate())
-        .provider(loginDto.getProvider())
+        .provider(Provider.valueOf(loginDto.getProvider()))
         .providerId(loginDto.getProviderId())
         .build();
     return memberRepository.save(member);

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -16,7 +16,6 @@ import com.jeju.nanaland.global.exception.ErrorCode;
 import com.jeju.nanaland.global.jwt.JwtUtil;
 import com.jeju.nanaland.global.jwt.dto.JwtResponseDto.JwtDto;
 import java.util.Optional;
-import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -94,9 +93,11 @@ public class MemberLoginService {
 
   // 임시로 만든 랜덤 프로필 사진
   private ImageFile getRandomProfileImageFile() {
-    Random random = new Random();
-    long randomId = random.nextInt(3) + 1;
-    return imageFileRepository.findById(randomId).get();
+    ImageFile imageFile = ImageFile.builder()
+        .originUrl("originUrl")
+        .thumbnailUrl("thumbnailUrl")
+        .build();
+    return imageFileRepository.save(imageFile);
   }
 
   @Transactional

--- a/src/main/java/com/jeju/nanaland/global/exception/ConflictException.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package com.jeju.nanaland.global.exception;
+
+public class ConflictException extends RuntimeException {
+
+  public ConflictException() {
+    super(ErrorCode.CONFLICT_DATA.getMessage());
+  }
+
+  public ConflictException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.global.exception;
 
 import static com.jeju.nanaland.global.exception.ErrorCode.BAD_REQUEST_EXCEPTION;
+import static com.jeju.nanaland.global.exception.ErrorCode.CONFLICT_DATA;
 import static com.jeju.nanaland.global.exception.ErrorCode.EXPIRED_TOKEN;
 import static com.jeju.nanaland.global.exception.ErrorCode.REQUEST_VALIDATION_EXCEPTION;
 import static com.jeju.nanaland.global.exception.ErrorCode.UNSUPPORTED_FILE_FORMAT;
@@ -56,6 +57,13 @@ public class ControllerAdvice {
   @ExceptionHandler(UnauthorizedException.class)
   public BaseResponse<String> handleUnauthorizedException(UnauthorizedException e) {
     return BaseResponse.error(EXPIRED_TOKEN, e.getMessage());
+  }
+
+  // 409에러
+  @ResponseStatus(HttpStatus.CONFLICT)
+  @ExceptionHandler(ConflictException.class)
+  public BaseResponse<String> handleConflictException(ConflictException e) {
+    return BaseResponse.error(CONFLICT_DATA, e.getMessage());
   }
 
   //415에러 (파일 확장자 오류)

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
@@ -21,7 +22,10 @@ public enum ErrorCode {
   ACCESS_DENIED(UNAUTHORIZED, "접근 권한이 없습니다."),
   INVALID_TOKEN(UNAUTHORIZED, "토큰이 유효하지 않습니다."),
 
-  MEMBER_NOT_FOUND(NOT_FOUND, "존재하는 회원을 찾을 수 없습니다.");
+  MEMBER_NOT_FOUND(NOT_FOUND, "존재하는 회원을 찾을 수 없습니다."),
+
+  CONFLICT_DATA(CONFLICT, "이미 존재하는 데이터입니다."),
+  MEMBER_DUPLICATE(CONFLICT, "이미 가입된 계정이 존재합니다.");
 
   private final HttpStatus httpStatus;
   private final String message;


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 이미 존재하는 회원인지 예외 처리 (기존에는 DB에 도달해야 확인할 수 있었던 상황,,)
- Enum valid 추가
- 임시로 랜덤 프로필 사진을 추가하는 함수를 간단하게 수정해두었습니다.

<br>

## 💬 To Reviewers
- [ ] 임시로 랜덤 프로필 사진을 부여하는 함수에서 오류가 발생했습니다. 이유는 `@OneToOne`으로 매핑되어있는데, 제가 id가 1 ~ 3인 이미지 파일을 랜덤으로 매핑하려고 했기 때문이었어요.
- [ ] 그래서 일단 임시로 이미지 파일을 생성하는 쪽으로 만들어둔 상황입니다. 생각해보니 추후에 프로필 사진과 닉네임으로 회원 정보를 수정해주는 API일 때, 넘겨져오는 프로필 사진이 없는 경우, 랜덤으로 OringinUrl과 ThumbnailUrl을 바꿔주면 될 것 같다고 생각했습니다.
- [ ] 그래서 일단 추가해야만 했던 이미지 파일 sql문은 필요가 없어져서 노션에서 삭제했습니다.

아,,, 이슈 번호를 커밋 메시지 앞에 붙이는 것을 까먹어버렸습니다.. 이미 push를 했던 지라 수정하려면 강제로 force로 push해야하는데 이건 좀 안될 것 같아 시도하지 않았습니다. 다음엔 꼭 잊지않고 번호 붙이겠습니다ㅠㅠ

<br>

## ☑️ Related Issue
> 관련 이슈
close #33 