### PR TITLE
[#54] Feat : 게시물 좋아요, 좋아요 취소

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/data/CategoryContent.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/data/CategoryContent.java
@@ -1,0 +1,9 @@
+package com.jeju.nanaland.domain.common.data;
+
+public enum CategoryContent {
+  NANA,
+  EXPERIENCE,
+  FESTIVAL,
+  NATURE,
+  MARKET
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Category.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Category.java
@@ -1,8 +1,11 @@
 package com.jeju.nanaland.domain.common.entity;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +19,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseEntity {
 
-  @NotBlank
+  @NotNull
   @Column(nullable = false, unique = true)
-  private String content;
+  @Enumerated(EnumType.STRING)
+  private CategoryContent content;
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/CategoryRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/CategoryRepository.java
@@ -1,10 +1,11 @@
 package com.jeju.nanaland.domain.common.repository;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Category;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-  public Optional<Category> findByContent(String content);
+  public Optional<Category> findByContent(CategoryContent content);
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/CategoryRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.jeju.nanaland.domain.common.repository;
+
+import com.jeju.nanaland.domain.common.entity.Category;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+  public Optional<Category> findByContent(String content);
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
@@ -30,7 +30,7 @@ public class ExperienceController {
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")

--- a/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
@@ -1,0 +1,29 @@
+package com.jeju.nanaland.domain.experience.controller;
+
+import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
+
+import com.jeju.nanaland.domain.experience.service.ExperienceService;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.jwt.AuthMember;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/experience")
+@RequiredArgsConstructor
+@Slf4j
+public class ExperienceController {
+
+  private final ExperienceService experienceService;
+
+  @PostMapping("/like/{id}")
+  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
+    String result = experienceService.toggleLikeStatus(member, id);
+    return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
@@ -6,6 +6,11 @@ import com.jeju.nanaland.domain.experience.service.ExperienceService;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,10 +22,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/experience")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "이색체험(Experience)", description = "이색체험(Experience) API입니다.")
 public class ExperienceController {
 
   private final ExperienceService experienceService;
 
+  @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
   @PostMapping("/like/{id}")
   public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
     String result = experienceService.toggleLikeStatus(member, id);

--- a/src/main/java/com/jeju/nanaland/domain/experience/dto/ExperienceRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/dto/ExperienceRequest.java
@@ -1,0 +1,13 @@
+package com.jeju.nanaland.domain.experience.dto;
+
+import lombok.Data;
+
+public class ExperienceRequest {
+
+  @Data
+  public static class LikeDto {
+
+    private Long postId;
+
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/dto/ExperienceResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/dto/ExperienceResponse.java
@@ -1,0 +1,5 @@
+package com.jeju.nanaland.domain.experience.dto;
+
+public class ExperienceResponse {
+
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
@@ -1,12 +1,8 @@
 package com.jeju.nanaland.domain.experience.service;
 
-import com.jeju.nanaland.domain.common.entity.Category;
-import com.jeju.nanaland.domain.common.repository.CategoryRepository;
-import com.jeju.nanaland.domain.favorite.entity.Favorite;
-import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
 import com.jeju.nanaland.domain.member.entity.Member;
-import com.jeju.nanaland.global.exception.ServerErrorException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,36 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ExperienceService {
 
-  private final CategoryRepository categoryRepository;
-  private final FavoriteRepository favoriteRepository;
+  private final FavoriteService favoriteService;
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
-    Category experienceCategory = categoryRepository.findByContent("EXPERIENCE")
-        .orElseThrow(() -> new ServerErrorException("EXPERIENCE에 해당하는 카테고리가 없습니다."));
-
-    Optional<Favorite> favoriteOptional = favoriteRepository.findByMemberAndCategoryAndPostId(
-        member, experienceCategory, postId);
-
-    // 좋아요 상태일 때
-    if (favoriteOptional.isPresent()) {
-      Favorite favorite = favoriteOptional.get();
-
-      // 좋아요 삭제
-      favoriteRepository.delete(favorite);
-      return "좋아요 삭제";
-    }
-    // 좋아요 상태가 아닐 때
-    else {
-      Favorite favorite = Favorite.builder()
-          .member(member)
-          .category(experienceCategory)
-          .postId(postId)
-          .build();
-
-      // 좋아요 추가
-      favoriteRepository.save(favorite);
-      return "좋아요 추가";
-    }
+    return favoriteService.toggleLikeStatus(member, CategoryContent.EXPERIENCE, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
@@ -1,0 +1,52 @@
+package com.jeju.nanaland.domain.experience.service;
+
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.repository.CategoryRepository;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.exception.ServerErrorException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExperienceService {
+
+  private final CategoryRepository categoryRepository;
+  private final FavoriteRepository favoriteRepository;
+
+  @Transactional
+  public String toggleLikeStatus(Member member, Long postId) {
+    Category experienceCategory = categoryRepository.findByContent("EXPERIENCE")
+        .orElseThrow(() -> new ServerErrorException("EXPERIENCE에 해당하는 카테고리가 없습니다."));
+
+    Optional<Favorite> favoriteOptional = favoriteRepository.findByMemberAndCategoryAndPostId(
+        member, experienceCategory, postId);
+
+    // 좋아요 상태일 때
+    if (favoriteOptional.isPresent()) {
+      Favorite favorite = favoriteOptional.get();
+
+      // 좋아요 삭제
+      favoriteRepository.delete(favorite);
+      return "좋아요 삭제";
+    }
+    // 좋아요 상태가 아닐 때
+    else {
+      Favorite favorite = Favorite.builder()
+          .member(member)
+          .category(experienceCategory)
+          .postId(postId)
+          .build();
+
+      // 좋아요 추가
+      favoriteRepository.save(favorite);
+      return "좋아요 추가";
+    }
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
@@ -1,8 +1,10 @@
 package com.jeju.nanaland.domain.experience.service;
 
 import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.experience.repository.ExperienceRepository;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ExperienceService {
 
+  private final ExperienceRepository experienceRepository;
   private final FavoriteService favoriteService;
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
+    experienceRepository.findById(postId)
+        .orElseThrow(() -> new BadRequestException("해당 id의 이색체험 게시물이 존재하지 않습니다."));
+
     return favoriteService.toggleLikeStatus(member, CategoryContent.EXPERIENCE, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,13 @@
+package com.jeju.nanaland.domain.favorite.repository;
+
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+  public Optional<Favorite> findByMemberAndCategoryAndPostId(Member member, Category category,
+      Long postId);
+}

--- a/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,74 @@
+package com.jeju.nanaland.domain.favorite.service;
+
+import static com.jeju.nanaland.domain.common.data.CategoryContent.EXPERIENCE;
+import static com.jeju.nanaland.domain.common.data.CategoryContent.FESTIVAL;
+import static com.jeju.nanaland.domain.common.data.CategoryContent.MARKET;
+import static com.jeju.nanaland.domain.common.data.CategoryContent.NANA;
+import static com.jeju.nanaland.domain.common.data.CategoryContent.NATURE;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.repository.CategoryRepository;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.exception.ServerErrorException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FavoriteService {
+
+  private final CategoryRepository categoryRepository;
+  private final FavoriteRepository favoriteRepository;
+
+  @Transactional
+  public String toggleLikeStatus(Member member, CategoryContent categoryContent, Long postId) {
+
+    Category category = switch (categoryContent) {
+      case NANA -> categoryRepository.findByContent(NANA)
+          .orElseThrow(() -> new ServerErrorException("NANA에 해당하는 카테고리가 없습니다."));
+
+      case EXPERIENCE -> categoryRepository.findByContent(EXPERIENCE)
+          .orElseThrow(() -> new ServerErrorException("EXPERIENCE에 해당하는 카테고리가 없습니다."));
+
+      case NATURE -> categoryRepository.findByContent(NATURE)
+          .orElseThrow(() -> new ServerErrorException("NATURE에 해당하는 카테고리가 없습니다."));
+
+      case MARKET -> categoryRepository.findByContent(MARKET)
+          .orElseThrow(() -> new ServerErrorException("MARKET에 해당하는 카테고리가 없습니다."));
+
+      case FESTIVAL -> categoryRepository.findByContent(FESTIVAL)
+          .orElseThrow(() -> new ServerErrorException("FESTIVAL에 해당하는 카테고리가 없습니다."));
+    };
+
+    Optional<Favorite> favoriteOptional = favoriteRepository.findByMemberAndCategoryAndPostId(
+        member, category, postId);
+
+    // 좋아요 상태일 때
+    if (favoriteOptional.isPresent()) {
+      Favorite favorite = favoriteOptional.get();
+
+      // 좋아요 삭제
+      favoriteRepository.delete(favorite);
+      return "좋아요 삭제";
+    }
+    // 좋아요 상태가 아닐 때
+    else {
+      Favorite favorite = Favorite.builder()
+          .member(member)
+          .category(category)
+          .postId(postId)
+          .build();
+
+      // 좋아요 추가
+      favoriteRepository.save(favorite);
+      return "좋아요 추가";
+    }
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/festival")
 @Slf4j
+@Tag(name = "축제(Festival)", description = "축제(Festival) API입니다.")
 public class FestivalController {
 
   private final FestivalService festivalService;

--- a/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
@@ -30,7 +30,7 @@ public class FestivalController {
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")

--- a/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
@@ -1,7 +1,19 @@
 package com.jeju.nanaland.domain.festival.controller;
 
+import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
+
+import com.jeju.nanaland.domain.festival.service.FestivalService;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.jwt.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class FestivalController {
 
+  private final FestivalService festivalService;
+
+  @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
+  @PostMapping("/like/{id}")
+  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
+    String result = festivalService.toggleLikeStatus(member, id);
+    return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
@@ -1,0 +1,14 @@
+package com.jeju.nanaland.domain.festival.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/festival")
+@Slf4j
+public class FestivalController {
+
+}

--- a/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
@@ -1,0 +1,17 @@
+package com.jeju.nanaland.domain.festival.service;
+
+import com.jeju.nanaland.domain.common.repository.CategoryRepository;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FestivalService {
+
+  private final CategoryRepository categoryRepository;
+  private final FavoriteRepository favoriteRepository;
+
+}

--- a/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
@@ -1,17 +1,22 @@
 package com.jeju.nanaland.domain.festival.service;
 
-import com.jeju.nanaland.domain.common.repository.CategoryRepository;
-import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FestivalService {
 
-  private final CategoryRepository categoryRepository;
-  private final FavoriteRepository favoriteRepository;
+  private final FavoriteService favoriteService;
 
+  @Transactional
+  public String toggleLikeStatus(Member member, Long postId) {
+    return favoriteService.toggleLikeStatus(member, CategoryContent.FESTIVAL, postId);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
@@ -2,7 +2,9 @@ package com.jeju.nanaland.domain.festival.service;
 
 import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.festival.repository.FestivalRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class FestivalService {
 
+  private final FestivalRepository festivalRepository;
   private final FavoriteService favoriteService;
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
+    festivalRepository.findById(postId)
+        .orElseThrow(() -> new BadRequestException("해당 id의 축제 게시물이 존재하지 않습니다."));
+
     return favoriteService.toggleLikeStatus(member, CategoryContent.FESTIVAL, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
@@ -30,7 +30,7 @@ public class MarketController {
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")

--- a/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
@@ -1,0 +1,41 @@
+package com.jeju.nanaland.domain.market.controller;
+
+import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
+
+import com.jeju.nanaland.domain.market.service.MarketService;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.jwt.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/market")
+@Slf4j
+@Tag(name = "전통시장(Market)", description = "전통시장(Market) API입니다.")
+public class MarketController {
+
+  private final MarketService marketService;
+
+  @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
+  @PostMapping("/like/{id}")
+  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
+    String result = marketService.toggleLikeStatus(member, id);
+    return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
@@ -1,0 +1,22 @@
+package com.jeju.nanaland.domain.market.service;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MarketService {
+
+  private final FavoriteService favoriteService;
+
+  @Transactional
+  public String toggleLikeStatus(Member member, Long postId) {
+    return favoriteService.toggleLikeStatus(member, CategoryContent.MARKET, postId);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
@@ -2,7 +2,9 @@ package com.jeju.nanaland.domain.market.service;
 
 import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.market.repository.MarketRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class MarketService {
 
+  private final MarketRepository marketRepository;
   private final FavoriteService favoriteService;
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
+    marketRepository.findById(postId)
+        .orElseThrow(() -> new BadRequestException("해당 id의 전통시장 게시물이 존재하지 않습니다."));
+
     return favoriteService.toggleLikeStatus(member, CategoryContent.MARKET, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
@@ -75,7 +75,7 @@ public class NanaController {
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")

--- a/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
@@ -1,5 +1,7 @@
 package com.jeju.nanaland.domain.nana.controller;
 
+import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
+
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse;
@@ -17,6 +19,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -69,5 +72,15 @@ public class NanaController {
         nanaService.getNanaDetail(id));
   }
 
-
+  @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
+  @PostMapping("/like/{id}")
+  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
+    String result = nanaService.toggleLikeStatus(member, id);
+    return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
@@ -1,6 +1,9 @@
 package com.jeju.nanaland.domain.nana.service;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnail;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnailDto;
@@ -17,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +29,7 @@ public class NanaService {
   private final NanaRepository nanaRepository;
   private final NanaTitleRepository nanaTitleRepository;
   private final NanaContentRepository nanaContentRepository;
+  private final FavoriteService favoriteService;
 
   //메인페이지에 보여지는 4개의 nana
   public List<NanaThumbnail> getMainNanaThumbnails(Locale locale) {
@@ -79,5 +84,10 @@ public class NanaService {
         .nanaDetails(nanaDetails)
         .build();
 
+  }
+
+  @Transactional
+  public String toggleLikeStatus(Member member, Long postId) {
+    return favoriteService.toggleLikeStatus(member, CategoryContent.NANA, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
@@ -88,6 +88,9 @@ public class NanaService {
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
+    nanaRepository.findById(postId)
+        .orElseThrow(() -> new BadRequestException("해당 id의 나나스픽 게시물이 존재하지 않습니다."));
+
     return favoriteService.toggleLikeStatus(member, CategoryContent.NANA, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
@@ -31,7 +31,7 @@ public class NatureController {
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")

--- a/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
@@ -1,0 +1,42 @@
+package com.jeju.nanaland.domain.nature.controller;
+
+
+import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
+
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.nature.service.NatureService;
+import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.jwt.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/nature")
+@Slf4j
+@Tag(name = "7대자연(Nature)", description = "7대자연(Nature) API입니다.")
+public class NatureController {
+
+  private final NatureService natureService;
+
+  @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
+  @PostMapping("/like/{id}")
+  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
+    String result = natureService.toggleLikeStatus(member, id);
+    return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
@@ -3,6 +3,8 @@ package com.jeju.nanaland.domain.nature.service;
 import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.nature.repository.NatureRepository;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class NatureService {
 
+  private final NatureRepository natureRepository;
   private final FavoriteService favoriteService;
 
   @Transactional
   public String toggleLikeStatus(Member member, Long postId) {
+    natureRepository.findById(postId)
+        .orElseThrow(() -> new BadRequestException("해당 id의 7대자연 게시물이 존재하지 않습니다."));
+
     return favoriteService.toggleLikeStatus(member, CategoryContent.NATURE, postId);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
@@ -1,0 +1,22 @@
+package com.jeju.nanaland.domain.nature.service;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NatureService {
+
+  private final FavoriteService favoriteService;
+
+  @Transactional
+  public String toggleLikeStatus(Member member, Long postId) {
+    return favoriteService.toggleLikeStatus(member, CategoryContent.NATURE, postId);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -28,7 +28,10 @@ public enum SuccessCode {
   // nana
   NANA_MAIN_SUCCESS(OK, "나나 메인 페이지 썸네일 조회 성공"),
   NANA_LIST_SUCCESS(OK, "나나 썸네일 리스트 조회 성공"),
-  NANA_DETAIL_SUCCESS(OK, "나나 상세 페이지 조회 성공");
+  NANA_DETAIL_SUCCESS(OK, "나나 상세 페이지 조회 성공"),
+
+  // favorite
+  POST_LIKE_TOGGLE_SUCCESS(OK, "게시물 좋아요 토글 요청 성공");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/test/java/com/jeju/nanaland/domain/entity/EntityImageFileMappingTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/entity/EntityImageFileMappingTest.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.domain.entity;
 
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Category;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Language;
@@ -94,7 +95,7 @@ class EntityImageFileMappingTest {
     em.persist(keyword);
 
     Category category = Category.builder()
-        .content("content")
+        .content(CategoryContent.EXPERIENCE)
         .build();
     em.persist(category);
 

--- a/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
@@ -1,5 +1,115 @@
 package com.jeju.nanaland.domain.experience.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.experience.entity.Experience;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
 class ExperienceServiceTest {
 
+  @Autowired
+  EntityManager em;
+  @Autowired
+  ExperienceService experienceService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  Language language;
+  Member member1, member2;
+  Experience experience;
+  Category category;
+
+  @BeforeEach
+  void init() {
+    ImageFile imageFile1 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile1);
+
+    ImageFile imageFile2 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile2);
+
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    member1 = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member1);
+
+    member2 = Member.builder()
+        .email("test2@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(1234567890L)
+        .nickname("nickname2")
+        .language(language)
+        .profileImageFile(imageFile2)
+        .build();
+    em.persist(member2);
+
+    experience = Experience.builder()
+        .imageFile(imageFile1)
+        .build();
+    em.persist(experience);
+
+    category = Category.builder()
+        .content("EXPERIENCE")
+        .build();
+    em.persist(category);
+  }
+
+  @Test
+  void toggleLikeStatusTest() {
+    /**
+     * WHEN
+     *
+     * member1 : toggleLikeStatus 2번 적용
+     * member2 : toggleLikeStatus 1번 적용
+     */
+    experienceService.toggleLikeStatus(member1, experience.getId());
+    experienceService.toggleLikeStatus(member1, experience.getId());
+
+    experienceService.toggleLikeStatus(member2, experience.getId());
+
+    Optional<Favorite> favoriteOptional1 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member1, category, experience.getId());
+    Optional<Favorite> favoriteOptional2 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member2, category, experience.getId());
+
+    /**
+     * THEN
+     *
+     * member1 = 좋아요 X, member2 = 좋아요
+     */
+    assertThat(favoriteOptional1.isPresent()).isFalse();
+    assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
 }

--- a/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.experience.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Category;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Language;
@@ -81,7 +82,7 @@ class ExperienceServiceTest {
     em.persist(experience);
 
     category = Category.builder()
-        .content("EXPERIENCE")
+        .content(CategoryContent.EXPERIENCE)
         .build();
     em.persist(category);
   }

--- a/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
@@ -12,8 +12,10 @@ import com.jeju.nanaland.domain.favorite.entity.Favorite;
 import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,5 +114,24 @@ class ExperienceServiceTest {
      */
     assertThat(favoriteOptional1.isPresent()).isFalse();
     assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+
+  @Test
+  void toggleLikeStatusFailedWithNoSuchPostIdTest() {
+    /**
+     * GIVEN
+     *
+     * 존재하지 않는 postId
+     */
+    Long postId = -1L;
+
+    /**
+     * WHEN
+     * THEN
+     *
+     * toggleLikeStatus 요청 시 BadRequestException 발생
+     */
+    Assertions.assertThatThrownBy(() -> experienceService.toggleLikeStatus(member1, postId))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
@@ -1,0 +1,5 @@
+package com.jeju.nanaland.domain.experience.service;
+
+class ExperienceServiceTest {
+
+}

--- a/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
@@ -12,8 +12,10 @@ import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
 import com.jeju.nanaland.domain.festival.entity.Festival;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,5 +114,24 @@ class FestivalServiceTest {
      */
     assertThat(favoriteOptional1.isPresent()).isFalse();
     assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+
+  @Test
+  void toggleLikeStatusFailedWithNoSuchPostIdTest() {
+    /**
+     * GIVEN
+     *
+     * 존재하지 않는 postId
+     */
+    Long postId = -1L;
+
+    /**
+     * WHEN
+     * THEN
+     *
+     * toggleLikeStatus 요청 시 BadRequestException 발생
+     */
+    Assertions.assertThatThrownBy(() -> festivalService.toggleLikeStatus(member1, postId))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
@@ -1,0 +1,116 @@
+package com.jeju.nanaland.domain.festival.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.festival.entity.Festival;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FestivalServiceTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  FestivalService festivalService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  Language language;
+  Member member1, member2;
+  Festival festival;
+  Category category;
+
+  @BeforeEach
+  void init() {
+    ImageFile imageFile1 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile1);
+
+    ImageFile imageFile2 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile2);
+
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    member1 = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member1);
+
+    member2 = Member.builder()
+        .email("test2@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(1234567890L)
+        .nickname("nickname2")
+        .language(language)
+        .profileImageFile(imageFile2)
+        .build();
+    em.persist(member2);
+
+    festival = Festival.builder()
+        .imageFile(imageFile1)
+        .build();
+    em.persist(festival);
+
+    category = Category.builder()
+        .content(CategoryContent.FESTIVAL)
+        .build();
+    em.persist(category);
+  }
+
+  @Test
+  void toggleLikeStatusTest() {
+    /**
+     * WHEN
+     *
+     * member1 : toggleLikeStatus 2번 적용
+     * member2 : toggleLikeStatus 1번 적용
+     */
+    festivalService.toggleLikeStatus(member1, festival.getId());
+    festivalService.toggleLikeStatus(member1, festival.getId());
+
+    festivalService.toggleLikeStatus(member2, festival.getId());
+
+    Optional<Favorite> favoriteOptional1 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member1, category, festival.getId());
+    Optional<Favorite> favoriteOptional2 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member2, category, festival.getId());
+
+    /**
+     * THEN
+     *
+     * member1 = 좋아요 X, member2 = 좋아요
+     */
+    assertThat(favoriteOptional1.isPresent()).isFalse();
+    assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -12,8 +12,10 @@ import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
 import com.jeju.nanaland.domain.market.entity.Market;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,5 +114,24 @@ class MarketServiceTest {
      */
     assertThat(favoriteOptional1.isPresent()).isFalse();
     assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+
+  @Test
+  void toggleLikeStatusFailedWithNoSuchPostIdTest() {
+    /**
+     * GIVEN
+     *
+     * 존재하지 않는 postId
+     */
+    Long postId = -1L;
+
+    /**
+     * WHEN
+     * THEN
+     *
+     * toggleLikeStatus 요청 시 BadRequestException 발생
+     */
+    Assertions.assertThatThrownBy(() -> marketService.toggleLikeStatus(member1, postId))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -1,0 +1,116 @@
+package com.jeju.nanaland.domain.market.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.market.entity.Market;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MarketServiceTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  MarketService marketService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  Language language;
+  Member member1, member2;
+  Market market;
+  Category category;
+
+  @BeforeEach
+  void init() {
+    ImageFile imageFile1 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile1);
+
+    ImageFile imageFile2 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile2);
+
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    member1 = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member1);
+
+    member2 = Member.builder()
+        .email("test2@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(1234567890L)
+        .nickname("nickname2")
+        .language(language)
+        .profileImageFile(imageFile2)
+        .build();
+    em.persist(member2);
+
+    market = Market.builder()
+        .imageFile(imageFile1)
+        .build();
+    em.persist(market);
+
+    category = Category.builder()
+        .content(CategoryContent.MARKET)
+        .build();
+    em.persist(category);
+  }
+
+  @Test
+  void toggleLikeStatusTest() {
+    /**
+     * WHEN
+     *
+     * member1 : toggleLikeStatus 2번 적용
+     * member2 : toggleLikeStatus 1번 적용
+     */
+    marketService.toggleLikeStatus(member1, market.getId());
+    marketService.toggleLikeStatus(member1, market.getId());
+
+    marketService.toggleLikeStatus(member2, market.getId());
+
+    Optional<Favorite> favoriteOptional1 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member1, category, market.getId());
+    Optional<Favorite> favoriteOptional2 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member2, category, market.getId());
+
+    /**
+     * THEN
+     *
+     * member1 = 좋아요 X, member2 = 좋아요
+     */
+    assertThat(favoriteOptional1.isPresent()).isFalse();
+    assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
@@ -12,8 +12,10 @@ import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import com.jeju.nanaland.domain.nana.entity.Nana;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,5 +114,24 @@ class NanaServiceTest {
      */
     assertThat(favoriteOptional1.isPresent()).isFalse();
     assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+
+  @Test
+  void toggleLikeStatusFailedWithNoSuchPostIdTest() {
+    /**
+     * GIVEN
+     *
+     * 존재하지 않는 postId
+     */
+    Long postId = -1L;
+
+    /**
+     * WHEN
+     * THEN
+     *
+     * toggleLikeStatus 요청 시 BadRequestException 발생
+     */
+    Assertions.assertThatThrownBy(() -> nanaService.toggleLikeStatus(member1, postId))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
@@ -1,0 +1,116 @@
+package com.jeju.nanaland.domain.nana.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.domain.nana.entity.Nana;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class NanaServiceTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  NanaService nanaService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  Language language;
+  Member member1, member2;
+  Nana nana;
+  Category category;
+
+  @BeforeEach
+  void init() {
+    ImageFile imageFile1 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile1);
+
+    ImageFile imageFile2 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile2);
+
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    member1 = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member1);
+
+    member2 = Member.builder()
+        .email("test2@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(1234567890L)
+        .nickname("nickname2")
+        .language(language)
+        .profileImageFile(imageFile2)
+        .build();
+    em.persist(member2);
+
+    nana = Nana.builder()
+        .version("version1")
+        .build();
+    em.persist(nana);
+
+    category = Category.builder()
+        .content(CategoryContent.NANA)
+        .build();
+    em.persist(category);
+  }
+
+  @Test
+  void toggleLikeStatusTest() {
+    /**
+     * WHEN
+     *
+     * member1 : toggleLikeStatus 2번 적용
+     * member2 : toggleLikeStatus 1번 적용
+     */
+    nanaService.toggleLikeStatus(member1, nana.getId());
+    nanaService.toggleLikeStatus(member1, nana.getId());
+
+    nanaService.toggleLikeStatus(member2, nana.getId());
+
+    Optional<Favorite> favoriteOptional1 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member1, category, nana.getId());
+    Optional<Favorite> favoriteOptional2 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member2, category, nana.getId());
+
+    /**
+     * THEN
+     *
+     * member1 = 좋아요 X, member2 = 좋아요
+     */
+    assertThat(favoriteOptional1.isPresent()).isFalse();
+    assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
@@ -12,8 +12,10 @@ import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import com.jeju.nanaland.domain.nature.entity.Nature;
+import com.jeju.nanaland.global.exception.BadRequestException;
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,5 +114,24 @@ class NatureServiceTest {
      */
     assertThat(favoriteOptional1.isPresent()).isFalse();
     assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+
+  @Test
+  void toggleLikeStatusFailedWithNoSuchPostIdTest() {
+    /**
+     * GIVEN
+     *
+     * 존재하지 않는 postId
+     */
+    Long postId = -1L;
+
+    /**
+     * WHEN
+     * THEN
+     *
+     * toggleLikeStatus 요청 시 BadRequestException 발생
+     */
+    Assertions.assertThatThrownBy(() -> natureService.toggleLikeStatus(member1, postId))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
@@ -1,0 +1,116 @@
+package com.jeju.nanaland.domain.nature.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.entity.Favorite;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.domain.nature.entity.Nature;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class NatureServiceTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  NatureService natureService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  Language language;
+  Member member1, member2;
+  Nature nature;
+  Category category;
+
+  @BeforeEach
+  void init() {
+    ImageFile imageFile1 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile1);
+
+    ImageFile imageFile2 = ImageFile.builder()
+        .originUrl("origin")
+        .thumbnailUrl("thumbnail")
+        .build();
+    em.persist(imageFile2);
+
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    member1 = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member1);
+
+    member2 = Member.builder()
+        .email("test2@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(1234567890L)
+        .nickname("nickname2")
+        .language(language)
+        .profileImageFile(imageFile2)
+        .build();
+    em.persist(member2);
+
+    nature = Nature.builder()
+        .imageFile(imageFile1)
+        .build();
+    em.persist(nature);
+
+    category = Category.builder()
+        .content(CategoryContent.NATURE)
+        .build();
+    em.persist(category);
+  }
+
+  @Test
+  void toggleLikeStatusTest() {
+    /**
+     * WHEN
+     *
+     * member1 : toggleLikeStatus 2번 적용
+     * member2 : toggleLikeStatus 1번 적용
+     */
+    natureService.toggleLikeStatus(member1, nature.getId());
+    natureService.toggleLikeStatus(member1, nature.getId());
+
+    natureService.toggleLikeStatus(member2, nature.getId());
+
+    Optional<Favorite> favoriteOptional1 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member1, category, nature.getId());
+    Optional<Favorite> favoriteOptional2 =
+        favoriteRepository.findByMemberAndCategoryAndPostId(member2, category, nature.getId());
+
+    /**
+     * THEN
+     *
+     * member1 = 좋아요 X, member2 = 좋아요
+     */
+    assertThat(favoriteOptional1.isPresent()).isFalse();
+    assertThat(favoriteOptional2.isPresent()).isTrue();
+  }
+}


### PR DESCRIPTION
## 📝 Description-
- 게시물 좋아요, 좋아요 취소 토글 기능 구현
- 해당 게시물에 대해 좋아요 상태라면 좋아요 취소, 좋아요 상태가 아니라면 좋아요 상태로 변경
- test 코드
  - 좋아요 2번 실행, 1번 실행 결과 테스트
  - 없는 게시물의 id로 요청 시 BadRequestException 반환 테스트

<br>

## 💬 To Reviewers
- Category의 String content 필드 -> Enum 타입 CategoryContent로 변경

<br>

## ☑️ Related Issue
- close #54 
