### PR TITLE
[Refactor] `@AuthMember` 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ application.yml
 ## test를 위한 controller
 TestController.java
 
+data.sql
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/controller/ExperienceController.java
@@ -3,7 +3,7 @@ package com.jeju.nanaland.domain.experience.controller;
 import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
 
 import com.jeju.nanaland.domain.experience.service.ExperienceService;
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,8 +34,9 @@ public class ExperienceController {
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")
-  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
-    String result = experienceService.toggleLikeStatus(member, id);
+  public BaseResponse<String> toggleLikeStatus(@AuthMember MemberInfoDto memberInfoDto,
+      @PathVariable Long id) {
+    String result = experienceService.toggleLikeStatus(memberInfoDto.getMember(), id);
     return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/controller/FestivalController.java
@@ -3,7 +3,7 @@ package com.jeju.nanaland.domain.festival.controller;
 import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
 
 import com.jeju.nanaland.domain.festival.service.FestivalService;
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,8 +34,9 @@ public class FestivalController {
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")
-  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
-    String result = festivalService.toggleLikeStatus(member, id);
+  public BaseResponse<String> toggleLikeStatus(@AuthMember MemberInfoDto memberInfoDto,
+      @PathVariable Long id) {
+    String result = festivalService.toggleLikeStatus(memberInfoDto.getMember(), id);
     return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/controller/MarketController.java
@@ -3,7 +3,7 @@ package com.jeju.nanaland.domain.market.controller;
 import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
 
 import com.jeju.nanaland.domain.market.service.MarketService;
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,8 +34,9 @@ public class MarketController {
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")
-  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
-    String result = marketService.toggleLikeStatus(member, id);
+  public BaseResponse<String> toggleLikeStatus(@AuthMember MemberInfoDto memberInfoDto,
+      @PathVariable Long id) {
+    String result = marketService.toggleLikeStatus(memberInfoDto.getMember(), id);
     return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -7,8 +7,8 @@ import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_TYPE_
 
 import com.jeju.nanaland.domain.member.dto.MemberRequest;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.RecommendPostDto;
-import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.service.MemberLoginService;
 import com.jeju.nanaland.domain.member.service.MemberTypeService;
 import com.jeju.nanaland.global.BaseResponse;
@@ -82,10 +82,10 @@ public class MemberController {
   })
   @PatchMapping("/type")
   public BaseResponse<Null> updateMemberType(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid MemberRequest.UpdateTypeDto request) {
 
-    memberTypeService.updateMemberType(member.getId(), request.getType());
+    memberTypeService.updateMemberType(memberInfoDto.getMember().getId(), request.getType());
     return BaseResponse.success(UPDATE_MEMBER_TYPE_SUCCESS);
   }
 
@@ -101,9 +101,10 @@ public class MemberController {
   })
   @GetMapping("/recommended")
   public BaseResponse<List<RecommendPostDto>> getRecommendedPosts(
-      @AuthMember Member member) {
+      @AuthMember MemberInfoDto memberInfoDto) {
 
-    List<RecommendPostDto> result = memberTypeService.getRecommendPostsByType(member.getId());
+    List<RecommendPostDto> result = memberTypeService.getRecommendPostsByType(
+        memberInfoDto.getMember().getId());
     return BaseResponse.success(GET_RECOMMENDED_POSTS_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
@@ -1,10 +1,27 @@
 package com.jeju.nanaland.domain.member.dto;
 
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
 public class MemberResponse {
+
+  @Data
+  @Builder
+  public static class MemberInfoDto {
+
+    private Member member;
+    private Language language;
+
+    @QueryProjection
+    public MemberInfoDto(Member member, Language language) {
+      this.member = member;
+      this.language = language;
+    }
+  }
 
   @Data
   @Builder

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepository.java
@@ -7,11 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
   Optional<Member> findByEmailAndProviderAndProviderId(String email, Provider provider,
       Long providerId);
-  
+
   @Query("select m from Member m join fetch m.roleSet where m.id = :memberId")
   Optional<Member> findMemberById(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.jeju.nanaland.domain.member.repository;
 
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import java.util.Optional;
@@ -8,4 +9,6 @@ public interface MemberRepositoryCustom {
 
   Optional<Member> findDuplicateMember(String email, Provider provider,
       Long providerId);
+
+  MemberInfoDto findMemberWithLanguage(Long memberId);
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
@@ -2,8 +2,12 @@ package com.jeju.nanaland.domain.member.repository;
 
 import static com.jeju.nanaland.domain.member.entity.QMember.member;
 
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
+import com.jeju.nanaland.domain.member.dto.QMemberResponse_MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.global.exception.BadRequestException;
+import com.jeju.nanaland.global.exception.ErrorCode;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +26,19 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .and(member.providerId.eq(providerId))
             ))
         .stream().findAny();
+  }
+
+  @Override
+  public MemberInfoDto findMemberWithLanguage(Long memberId) {
+
+    return Optional.ofNullable(queryFactory
+            .select(new QMemberResponse_MemberInfoDto(
+                member, member.language
+            ))
+            .from(member)
+            .leftJoin(member.language)
+            .where(member.id.eq(memberId))
+            .fetchOne())
+        .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -9,7 +9,6 @@ import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
-import com.jeju.nanaland.domain.member.repository.MemberRepositoryCustom;
 import com.jeju.nanaland.global.exception.BadRequestException;
 import com.jeju.nanaland.global.exception.ConflictException;
 import com.jeju.nanaland.global.exception.ErrorCode;
@@ -25,7 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberLoginService {
 
   private final MemberRepository memberRepository;
-  private final MemberRepositoryCustom memberRepositoryCustom;
   private final LanguageRepository languageRepository;
   private final ImageFileRepository imageFileRepository;
   private final JwtUtil jwtUtil;
@@ -63,7 +61,7 @@ public class MemberLoginService {
 
   private Member createMember(LoginDto loginDto) {
 
-    Optional<Member> memberOptional = memberRepositoryCustom.findDuplicateMember(
+    Optional<Member> memberOptional = memberRepository.findDuplicateMember(
         loginDto.getEmail(),
         Provider.valueOf(loginDto.getProvider()),
         loginDto.getProviderId());

--- a/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
@@ -2,8 +2,7 @@ package com.jeju.nanaland.domain.nana.controller;
 
 import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
 
-import com.jeju.nanaland.domain.common.entity.Locale;
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaDetailDto;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnailDto;
@@ -38,10 +37,10 @@ public class NanaController {
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
   @GetMapping
-  public BaseResponse<List<NanaResponse.NanaThumbnail>> nanaMainPage(@AuthMember Member member) {
-    Locale locale = member.getLanguage().getLocale();
+  public BaseResponse<List<NanaResponse.NanaThumbnail>> nanaMainPage(
+      @AuthMember MemberInfoDto memberInfoDto) {
     return BaseResponse.success(SuccessCode.NANA_MAIN_SUCCESS,
-        nanaService.getMainNanaThumbnails(locale));
+        nanaService.getMainNanaThumbnails(memberInfoDto.getLanguage().getLocale()));
   }
 
   @Operation(
@@ -52,11 +51,10 @@ public class NanaController {
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
   @GetMapping("/list")
-  public BaseResponse<NanaThumbnailDto> nanaAll(@AuthMember Member member, int page,
+  public BaseResponse<NanaThumbnailDto> nanaAll(@AuthMember MemberInfoDto memberInfoDto, int page,
       int size) {
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SuccessCode.NANA_LIST_SUCCESS,
-        nanaService.getNanaThumbnails(locale, page, size));
+        nanaService.getNanaThumbnails(memberInfoDto.getLanguage().getLocale(), page, size));
   }
 
   @Operation(
@@ -79,8 +77,9 @@ public class NanaController {
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")
-  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
-    String result = nanaService.toggleLikeStatus(member, id);
+  public BaseResponse<String> toggleLikeStatus(@AuthMember MemberInfoDto memberInfoDto,
+      @PathVariable Long id) {
+    String result = nanaService.toggleLikeStatus(memberInfoDto.getMember(), id);
     return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/controller/NatureController.java
@@ -3,7 +3,7 @@ package com.jeju.nanaland.domain.nature.controller;
 
 import static com.jeju.nanaland.global.exception.SuccessCode.POST_LIKE_TOGGLE_SUCCESS;
 
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.nature.service.NatureService;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
@@ -35,8 +35,9 @@ public class NatureController {
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/like/{id}")
-  public BaseResponse<String> toggleLikeStatus(@AuthMember Member member, @PathVariable Long id) {
-    String result = natureService.toggleLikeStatus(member, id);
+  public BaseResponse<String> toggleLikeStatus(@AuthMember MemberInfoDto memberInfoDto,
+      @PathVariable Long id) {
+    String result = natureService.toggleLikeStatus(memberInfoDto.getMember(), id);
     return BaseResponse.success(POST_LIKE_TOGGLE_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
@@ -2,8 +2,7 @@ package com.jeju.nanaland.domain.search.controller;
 
 import static com.jeju.nanaland.global.exception.SuccessCode.SEARCH_SUCCESS;
 
-import com.jeju.nanaland.domain.common.entity.Locale;
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.search.dto.SearchResponse;
 import com.jeju.nanaland.domain.search.dto.SearchResponse.CategoryDto;
 import com.jeju.nanaland.domain.search.service.SearchService;
@@ -41,13 +40,12 @@ public class SearchController {
   })
   @GetMapping("/category")
   public BaseResponse<CategoryDto> searchCategory(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword) {
 
-    log.info("test");
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getCategorySearchResultDto(member, keyword, locale));
+        searchService.getCategorySearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale()));
   }
 
   @Operation(
@@ -59,14 +57,14 @@ public class SearchController {
   })
   @GetMapping("/nature")
   public BaseResponse<SearchResponse.ResultDto> searchNature(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getNatureSearchResultDto(member, keyword, locale, page, size));
+        searchService.getNatureSearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale(), page, size));
   }
 
   @Operation(
@@ -78,14 +76,14 @@ public class SearchController {
   })
   @GetMapping("/festival")
   public BaseResponse<SearchResponse.ResultDto> searchFestival(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getFestivalSearchResultDto(member, keyword, locale, page, size));
+        searchService.getFestivalSearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale(), page, size));
   }
 
   @Operation(
@@ -97,14 +95,14 @@ public class SearchController {
   })
   @GetMapping("/experience")
   public BaseResponse<SearchResponse.ResultDto> searchExperience(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getExperienceSearchResultDto(member, keyword, locale, page, size));
+        searchService.getExperienceSearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale(), page, size));
   }
 
   @Operation(
@@ -116,14 +114,14 @@ public class SearchController {
   })
   @GetMapping("/market")
   public BaseResponse<SearchResponse.ResultDto> searchMarket(
-      @AuthMember Member member,
+      @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    Locale locale = member.getLanguage().getLocale();
     return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getMarketSearchResultDto(member, keyword, locale, page, size));
+        searchService.getMarketSearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale(), page, size));
   }
 
   @Operation(
@@ -134,9 +132,9 @@ public class SearchController {
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
   @GetMapping("/popular")
-  public BaseResponse<List<String>> getPopularSearch(@AuthMember Member member) {
+  public BaseResponse<List<String>> getPopularSearch(@AuthMember MemberInfoDto memberInfoDto) {
 
-    Locale locale = member.getLanguage().getLocale();
-    return BaseResponse.success(SEARCH_SUCCESS, searchService.getPopularSearch(locale));
+    return BaseResponse.success(SEARCH_SUCCESS,
+        searchService.getPopularSearch(memberInfoDto.getLanguage().getLocale()));
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/jeju/nanaland/global/jwt/AuthMemberArgumentResolver.java
@@ -1,9 +1,7 @@
 package com.jeju.nanaland.global.jwt;
 
-import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
-import com.jeju.nanaland.global.exception.BadRequestException;
-import com.jeju.nanaland.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
@@ -23,7 +21,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
   @Override
   public boolean supportsParameter(MethodParameter parameter) {
     boolean hasAnnotation = parameter.getParameterAnnotation(AuthMember.class) != null;
-    boolean hasMemberType = Member.class.isAssignableFrom(parameter.getParameterType());
+    boolean hasMemberType = MemberInfoDto.class.isAssignableFrom(parameter.getParameterType());
     return hasAnnotation && hasMemberType;
   }
 
@@ -33,7 +31,6 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
     String bearerAccessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
     String accessToken = jwtUtil.resolveToken(bearerAccessToken);
     String memberId = jwtUtil.getMemberIdFromAccess(accessToken);
-    return memberRepository.findById(Long.valueOf(memberId))
-        .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
+    return memberRepository.findMemberWithLanguage(Long.valueOf(memberId));
   }
 }


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- `@AuthMember`에서 언어도 조회해오도록 수정

<br>

## 💬 To Reviewers
- [ ] 기존의 `@AuthMember`을 사용하면, 회원의 언어를 조회하는 쿼리가 매번 한 번씩 더 나가게 되어, `MemberInfoDto`에 Member와 Language를 담을 수 있도록 하여서, 조인하는 쿼리로 변경하여 쿼리문 한 번에 조회해올 수 있도록 하였습니다.

<br>

## ☑️ Related Issue
> 관련 이슈
