### PR TITLE
 [Refactor] 찜리스트

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
@@ -137,7 +137,7 @@ public class FavoriteController {
       @ApiResponse(responseCode = "404", description = "카테고리에 해당하는 게시물 id가 존재하지 않는 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
-  @PostMapping("/like/{id}")
+  @PostMapping("/like")
   public BaseResponse<FavoriteResponse.StatusDto> toggleLikeStatus(
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid LikeToggleDto likeToggleDto) {

--- a/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
@@ -119,6 +119,12 @@ public class FavoriteController {
     return BaseResponse.success(SuccessCode.GET_FAVORITE_LIST_SUCCESS, resultDto);
   }
 
+  @Operation(summary = "나나스픽 찜리스트 조회", description = "나나스픽 찜리스트 조회")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우 또는 해당 id의 게시물이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
   @GetMapping("/nana/list")
   public BaseResponse<FavoriteResponse.NanaDto> getNanaFavoriteList(
       @AuthMember MemberInfoDto memberInfoDto,

--- a/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/controller/FavoriteController.java
@@ -119,11 +119,16 @@ public class FavoriteController {
     return BaseResponse.success(SuccessCode.GET_FAVORITE_LIST_SUCCESS, resultDto);
   }
 
-  // TODO: NANA 찜리스트
-//  @GetMapping("/nana/list")
-//  public BaseResponse<FavoriteResponse.AllCategoryDto> getAllFavoriteList() {
-//    return null;
-//  }
+  @GetMapping("/nana/list")
+  public BaseResponse<FavoriteResponse.NanaDto> getNanaFavoriteList(
+      @AuthMember MemberInfoDto memberInfoDto,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "12") int size) {
+
+    FavoriteResponse.NanaDto resultDto =
+        favoriteService.getNanaFavoriteList(memberInfoDto, page, size);
+    return BaseResponse.success(SuccessCode.GET_FAVORITE_LIST_SUCCESS, resultDto);
+  }
 
   @Operation(summary = "좋아요 토글", description = "좋아요 토글 기능 (좋아요 상태 -> 좋아요 취소 상태, 좋아요 취소 상태 -> 좋아요 상태)")
   @ApiResponses(value = {

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryCustom.java
@@ -25,5 +25,9 @@ public interface FavoriteRepositoryCustom {
 
   ThumbnailDto findMarketThumbnailByPostId(Long postId, Locale locale);
 
+  Page<ThumbnailDto> findNanaThumbnails(Long memberId, Locale locale, Pageable pageable);
+
+  ThumbnailDto findNanaThumbnailByPostId(Long postId, Locale locale);
+
   Page<Favorite> findAllCategoryFavorite(Member member, Pageable pageable);
 }

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -9,6 +9,7 @@ import static com.jeju.nanaland.domain.festival.entity.QFestival.festival;
 import static com.jeju.nanaland.domain.festival.entity.QFestivalTrans.festivalTrans;
 import static com.jeju.nanaland.domain.market.entity.QMarket.market;
 import static com.jeju.nanaland.domain.market.entity.QMarketTrans.marketTrans;
+import static com.jeju.nanaland.domain.nana.entity.QNana.nana;
 import static com.jeju.nanaland.domain.nana.entity.QNanaTitle.nanaTitle;
 import static com.jeju.nanaland.domain.nature.entity.QNature.nature;
 import static com.jeju.nanaland.domain.nature.entity.QNatureTrans.natureTrans;
@@ -36,7 +37,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
   public Page<ThumbnailDto> findNatureThumbnails(Long memberId, Locale locale, Pageable pageable) {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            favorite.postId,
+            nature.id,
             natureTrans.title,
             imageFile.thumbnailUrl
         ))
@@ -91,7 +92,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
       Pageable pageable) {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            favorite.postId,
+            experience.id,
             experienceTrans.title,
             imageFile.thumbnailUrl
         ))
@@ -146,7 +147,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
       Pageable pageable) {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            favorite.postId,
+            festival.id,
             festivalTrans.title,
             imageFile.thumbnailUrl
         ))
@@ -201,7 +202,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
       Pageable pageable) {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            favorite.postId,
+            market.id,
             marketTrans.title,
             imageFile.thumbnailUrl
         ))
@@ -256,12 +257,13 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
       Pageable pageable) {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            favorite.postId,
+            nana.id,
             nanaTitle.heading,
             imageFile.thumbnailUrl
         ))
         .from(favorite)
-        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .join(nana).on(favorite.postId.eq(nana.id))
+        .join(nanaTitle).on(nana.eq(nanaTitle.nana))
         .leftJoin(nanaTitle.imageFile, imageFile)
         .leftJoin(nanaTitle.language, language)
         .where(favorite.category.content.eq(CategoryContent.NANA)
@@ -274,7 +276,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
     JPAQuery<Long> countQuery = queryFactory
         .select(favorite.count())
         .from(favorite)
-        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .join(nana).on(favorite.postId.eq(nana.id))
+        .join(nanaTitle).on(nana.eq(nanaTitle.nana))
         .leftJoin(nanaTitle.imageFile, imageFile)
         .leftJoin(nanaTitle.language, language)
         .where(favorite.category.content.eq(CategoryContent.NANA)
@@ -290,12 +293,13 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
   public ThumbnailDto findNanaThumbnailByPostId(Long postId, Locale locale) {
     return queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            nanaTitle.id,
+            nana.id,
             nanaTitle.heading,
             imageFile.thumbnailUrl
         ))
         .from(favorite)
-        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .join(nana).on(favorite.postId.eq(nana.id))
+        .join(nanaTitle).on(nana.eq(nanaTitle.nana))
         .leftJoin(nanaTitle.imageFile, imageFile)
         .leftJoin(nanaTitle.language, language)
         .where(favorite.category.content.eq(CategoryContent.NANA)

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -83,6 +83,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(natureTrans.language, language)
         .where(favorite.category.content.eq(CategoryContent.NATURE)
+            .and(favorite.postId.eq(postId))
             .and(language.locale.eq(locale)))
         .fetchOne();
   }
@@ -138,6 +139,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experienceTrans.language, language)
         .where(favorite.category.content.eq(CategoryContent.EXPERIENCE)
+            .and(favorite.postId.eq(postId))
             .and(language.locale.eq(locale)))
         .fetchOne();
   }
@@ -193,6 +195,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festivalTrans.language, language)
         .where(favorite.category.content.eq(CategoryContent.FESTIVAL)
+            .and(favorite.postId.eq(postId))
             .and(language.locale.eq(locale)))
         .fetchOne();
   }
@@ -248,6 +251,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(marketTrans.language, language)
         .where(favorite.category.content.eq(CategoryContent.MARKET)
+            .and(favorite.postId.eq(postId))
             .and(language.locale.eq(locale)))
         .fetchOne();
   }
@@ -303,6 +307,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(nanaTitle.imageFile, imageFile)
         .leftJoin(nanaTitle.language, language)
         .where(favorite.category.content.eq(CategoryContent.NANA)
+            .and(favorite.postId.eq(postId))
             .and(language.locale.eq(locale)))
         .fetchOne();
   }

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -257,7 +257,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
     List<ThumbnailDto> resultDto = queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
             favorite.postId,
-            marketTrans.title,
+            nanaTitle.heading,
             imageFile.thumbnailUrl
         ))
         .from(favorite)
@@ -290,8 +290,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
   public ThumbnailDto findNanaThumbnailByPostId(Long postId, Locale locale) {
     return queryFactory
         .select(new QFavoriteResponse_ThumbnailDto(
-            market.id,
-            marketTrans.title,
+            nanaTitle.id,
+            nanaTitle.heading,
             imageFile.thumbnailUrl
         ))
         .from(favorite)

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -9,9 +9,11 @@ import static com.jeju.nanaland.domain.festival.entity.QFestival.festival;
 import static com.jeju.nanaland.domain.festival.entity.QFestivalTrans.festivalTrans;
 import static com.jeju.nanaland.domain.market.entity.QMarket.market;
 import static com.jeju.nanaland.domain.market.entity.QMarketTrans.marketTrans;
+import static com.jeju.nanaland.domain.nana.entity.QNanaTitle.nanaTitle;
 import static com.jeju.nanaland.domain.nature.entity.QNature.nature;
 import static com.jeju.nanaland.domain.nature.entity.QNatureTrans.natureTrans;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.favorite.dto.FavoriteResponse.ThumbnailDto;
 import com.jeju.nanaland.domain.favorite.dto.QFavoriteResponse_ThumbnailDto;
@@ -43,7 +45,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(nature.natureTrans, natureTrans)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(natureTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.NATURE)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -56,7 +59,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(nature.natureTrans, natureTrans)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(natureTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.NATURE)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize());
@@ -72,11 +76,13 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
             natureTrans.title,
             imageFile.thumbnailUrl
         ))
-        .from(nature)
+        .from(favorite)
+        .join(nature).on(favorite.postId.eq(nature.id))
         .leftJoin(nature.natureTrans, natureTrans)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(natureTrans.language, language)
-        .where(nature.id.eq(postId).and(language.locale.eq(locale)))
+        .where(favorite.category.content.eq(CategoryContent.NATURE)
+            .and(language.locale.eq(locale)))
         .fetchOne();
   }
 
@@ -94,7 +100,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(experience.experienceTrans, experienceTrans)
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experienceTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.EXPERIENCE)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -107,7 +114,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(experience.experienceTrans, experienceTrans)
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experienceTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.EXPERIENCE)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize());
@@ -123,11 +131,13 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
             experienceTrans.title,
             imageFile.thumbnailUrl
         ))
-        .from(experience)
+        .from(favorite)
+        .join(experience).on(favorite.postId.eq(experience.id))
         .leftJoin(experience.experienceTrans, experienceTrans)
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experienceTrans.language, language)
-        .where(experience.id.eq(postId).and(language.locale.eq(locale)))
+        .where(favorite.category.content.eq(CategoryContent.EXPERIENCE)
+            .and(language.locale.eq(locale)))
         .fetchOne();
   }
 
@@ -145,7 +155,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(festival.festivalTrans, festivalTrans)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festivalTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.FESTIVAL)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -158,7 +169,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(festival.festivalTrans, festivalTrans)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festivalTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.FESTIVAL)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize());
@@ -174,11 +186,13 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
             festivalTrans.title,
             imageFile.thumbnailUrl
         ))
-        .from(festival)
+        .from(favorite)
+        .join(festival).on(favorite.postId.eq(festival.id))
         .leftJoin(festival.festivalTrans, festivalTrans)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festivalTrans.language, language)
-        .where(festival.id.eq(postId).and(language.locale.eq(locale)))
+        .where(favorite.category.content.eq(CategoryContent.FESTIVAL)
+            .and(language.locale.eq(locale)))
         .fetchOne();
   }
 
@@ -196,7 +210,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(market.marketTrans, marketTrans)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(marketTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.MARKET)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -209,7 +224,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         .leftJoin(market.marketTrans, marketTrans)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(marketTrans.language, language)
-        .where(language.locale.eq(locale))
+        .where(favorite.category.content.eq(CategoryContent.MARKET)
+            .and(language.locale.eq(locale)))
         .orderBy(favorite.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize());
@@ -225,11 +241,65 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
             marketTrans.title,
             imageFile.thumbnailUrl
         ))
-        .from(market)
+        .from(favorite)
+        .join(market).on(favorite.postId.eq(market.id))
         .leftJoin(market.marketTrans, marketTrans)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(marketTrans.language, language)
-        .where(market.id.eq(postId).and(language.locale.eq(locale)))
+        .where(favorite.category.content.eq(CategoryContent.MARKET)
+            .and(language.locale.eq(locale)))
+        .fetchOne();
+  }
+
+  @Override
+  public Page<ThumbnailDto> findNanaThumbnails(Long memberId, Locale locale,
+      Pageable pageable) {
+    List<ThumbnailDto> resultDto = queryFactory
+        .select(new QFavoriteResponse_ThumbnailDto(
+            favorite.postId,
+            marketTrans.title,
+            imageFile.thumbnailUrl
+        ))
+        .from(favorite)
+        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .leftJoin(nanaTitle.imageFile, imageFile)
+        .leftJoin(nanaTitle.language, language)
+        .where(favorite.category.content.eq(CategoryContent.NANA)
+            .and(language.locale.eq(locale)))
+        .orderBy(favorite.createdAt.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory
+        .select(favorite.count())
+        .from(favorite)
+        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .leftJoin(nanaTitle.imageFile, imageFile)
+        .leftJoin(nanaTitle.language, language)
+        .where(favorite.category.content.eq(CategoryContent.NANA)
+            .and(language.locale.eq(locale)))
+        .orderBy(favorite.createdAt.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize());
+
+    return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
+  }
+
+  @Override
+  public ThumbnailDto findNanaThumbnailByPostId(Long postId, Locale locale) {
+    return queryFactory
+        .select(new QFavoriteResponse_ThumbnailDto(
+            market.id,
+            marketTrans.title,
+            imageFile.thumbnailUrl
+        ))
+        .from(favorite)
+        .join(nanaTitle).on(favorite.postId.eq(nanaTitle.id))
+        .leftJoin(nanaTitle.imageFile, imageFile)
+        .leftJoin(nanaTitle.language, language)
+        .where(favorite.category.content.eq(CategoryContent.NANA)
+            .and(language.locale.eq(locale)))
         .fetchOne();
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -205,7 +205,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
     JPAQuery<Long> countQuery = queryFactory
         .select(favorite.count())
         .from(favorite)
-        .join(market).on(favorite.postId.eq(marketTrans.id))
+        .join(market).on(favorite.postId.eq(market.id))
         .leftJoin(market.marketTrans, marketTrans)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(marketTrans.language, language)

--- a/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
@@ -64,6 +64,7 @@ public class FavoriteService {
     for (Favorite favorite : favorites) {
       CategoryContent category = favorite.getCategory().getContent();
       Long postId = favorite.getPostId();
+      log.info("postId: {}", postId);
 
       switch (category) {
         case NANA -> {

--- a/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
@@ -56,13 +56,22 @@ public class FavoriteService {
     Locale locale = memberInfoDto.getLanguage().getLocale();
     Pageable pageable = PageRequest.of(page, size);
 
+    // Favorite 테이블에서 유저 id에 해당하는 튜플 모두 조회
     Page<Favorite> favorites = favoriteRepository.findAllCategoryFavorite(member, pageable);
     List<ThumbnailDto> thumbnailDtoList = new ArrayList<>();
+
+    // Favorite의 postId, 카테고리 정보를 통해 튜플 하나하나 조회
     for (Favorite favorite : favorites) {
       CategoryContent category = favorite.getCategory().getContent();
       Long postId = favorite.getPostId();
 
       switch (category) {
+        case NANA -> {
+          ThumbnailDto thumbnailDto = favoriteRepository.findNanaThumbnailByPostId(postId,
+              locale);
+          thumbnailDto.setCategory(NANA.name());
+          thumbnailDtoList.add(thumbnailDto);
+        }
         case NATURE -> {
           ThumbnailDto thumbnailDto = favoriteRepository.findNatureThumbnailByPostId(postId,
               locale);
@@ -176,6 +185,27 @@ public class FavoriteService {
     }
 
     return FavoriteResponse.MarketDto.builder()
+        .totalElements(thumbnails.getTotalElements())
+        .data(thumbnailDtoList)
+        .build();
+  }
+
+  public FavoriteResponse.NanaDto getNanaFavoriteList(MemberInfoDto memberInfoDto, int page,
+      int size) {
+
+    Long memberId = memberInfoDto.getMember().getId();
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Pageable pageable = PageRequest.of(page, size);
+
+    Page<ThumbnailDto> thumbnails = favoriteRepository.findNanaThumbnails(memberId, locale,
+        pageable);
+    List<ThumbnailDto> thumbnailDtoList = new ArrayList<>();
+    for (ThumbnailDto thumbnailDto : thumbnails) {
+      thumbnailDto.setCategory(NANA.name());
+      thumbnailDtoList.add(thumbnailDto);
+    }
+
+    return FavoriteResponse.NanaDto.builder()
         .totalElements(thumbnails.getTotalElements())
         .data(thumbnailDtoList)
         .build();

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/FestivalTrans.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.festival.entity;
 
 import com.jeju.nanaland.domain.common.entity.CommonTrans;
 import com.jeju.nanaland.domain.common.entity.Language;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -26,6 +27,7 @@ public class FestivalTrans extends CommonTrans {
 
   private String intro;
 
+  @Column(columnDefinition = "VARCHAR(1024)")
   private String fee;
 
   @Builder

--- a/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
@@ -1,0 +1,232 @@
+package com.jeju.nanaland.domain.favorite.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Category;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.dto.FavoriteRequest.LikeToggleDto;
+import com.jeju.nanaland.domain.favorite.dto.FavoriteResponse.AllCategoryDto;
+import com.jeju.nanaland.domain.favorite.dto.FavoriteResponse.FestivalDto;
+import com.jeju.nanaland.domain.favorite.dto.FavoriteResponse.NanaDto;
+import com.jeju.nanaland.domain.favorite.dto.FavoriteResponse.StatusDto;
+import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import com.jeju.nanaland.domain.festival.entity.Festival;
+import com.jeju.nanaland.domain.festival.entity.FestivalTrans;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.domain.nana.entity.Nana;
+import com.jeju.nanaland.domain.nana.entity.NanaTitle;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class FavoriteServiceTest {
+
+  @Autowired
+  EntityManager em;
+  @Autowired
+  FavoriteService favoriteService;
+  @Autowired
+  FavoriteRepository favoriteRepository;
+
+  ImageFile imageFile1, imageFile2, imageFile3;
+  Language language;
+  Member member;
+  MemberInfoDto memberInfoDto;
+
+  @BeforeEach
+  void init() {
+    // imageFile
+    imageFile1 = ImageFile.builder()
+        .originUrl("origin1")
+        .thumbnailUrl("thumbnail1")
+        .build();
+    imageFile2 = ImageFile.builder()
+        .originUrl("origin2")
+        .thumbnailUrl("thumbnail2")
+        .build();
+    imageFile3 = ImageFile.builder()
+        .originUrl("origin3")
+        .thumbnailUrl("thumbnail3")
+        .build();
+    em.persist(imageFile1);
+    em.persist(imageFile2);
+    em.persist(imageFile3);
+
+    // language
+    language = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yy-mm-dd")
+        .build();
+    em.persist(language);
+
+    // member
+    member = Member.builder()
+        .email("test@naver.com")
+        .provider(Provider.KAKAO)
+        .providerId(123456789L)
+        .nickname("nickname1")
+        .language(language)
+        .profileImageFile(imageFile1)
+        .build();
+    em.persist(member);
+
+    // memberInfoDto
+    memberInfoDto = MemberInfoDto.builder()
+        .language(language)
+        .member(member)
+        .build();
+
+    // category
+    Category festivalCategory = Category.builder()
+        .content(CategoryContent.FESTIVAL)
+        .build();
+    Category natureCategory = Category.builder()
+        .content(CategoryContent.NATURE)
+        .build();
+    Category nanaCategory = Category.builder()
+        .content(CategoryContent.NANA)
+        .build();
+
+    em.persist(natureCategory);
+    em.persist(festivalCategory);
+    em.persist(nanaCategory);
+  }
+
+  @Test
+  void likeToggleTest() {
+    /**
+     * GIVEN
+     *
+     * festival, nana 생성
+     */
+    Festival festival = Festival.builder()
+        .imageFile(imageFile1)
+        .build();
+    em.persist(festival);
+
+    Nana nana = Nana.builder()
+        .version("1")
+        .build();
+    em.persist(nana);
+
+    NanaTitle nanaTitle = NanaTitle.builder()
+        .imageFile(imageFile1)
+        .heading("heading")
+        .subHeading("subHeading")
+        .language(language)
+        .nana(nana)
+        .build();
+    em.persist(nanaTitle);
+
+    LikeToggleDto festivalLikeToggleDto = new LikeToggleDto();
+    festivalLikeToggleDto.setCategory(CategoryContent.FESTIVAL.name());
+    festivalLikeToggleDto.setId(festival.getId());
+
+    LikeToggleDto nanaLikeToggleDto = new LikeToggleDto();
+    nanaLikeToggleDto.setCategory(CategoryContent.NANA.name());
+    nanaLikeToggleDto.setId(nana.getId());
+
+    /**
+     * WHEN
+     */
+    StatusDto festivalStatusDto = favoriteService.toggleLikeStatus(memberInfoDto,
+        festivalLikeToggleDto);
+
+    StatusDto nanaStatusDto1 = favoriteService.toggleLikeStatus(memberInfoDto, nanaLikeToggleDto);
+    StatusDto nanaStatusDto2 = favoriteService.toggleLikeStatus(memberInfoDto, nanaLikeToggleDto);
+
+    /**
+     * THEN
+     */
+    assertThat(festivalStatusDto.isFavorite()).isTrue();
+    assertThat(nanaStatusDto1.isFavorite()).isTrue();
+    assertThat(nanaStatusDto2.isFavorite()).isFalse();
+  }
+
+  @Test
+  void favoriteListTest() {
+    /**
+     * GIVEN
+     *
+     * festival, nana 생성
+     */
+    Festival festival1 = Festival.builder()
+        .imageFile(imageFile1)
+        .season("봄")
+        .build();
+    em.persist(festival1);
+    FestivalTrans festivalTrans1 = FestivalTrans.builder()
+        .festival(festival1)
+        .language(language)
+        .addressTag("제주시")
+        .title("축제1")
+        .build();
+    em.persist(festivalTrans1);
+    Festival festival2 = Festival.builder()
+        .imageFile(imageFile2)
+        .season("여름")
+        .build();
+    em.persist(festival2);
+    FestivalTrans festivalTrans2 = FestivalTrans.builder()
+        .festival(festival2)
+        .language(language)
+        .addressTag("서귀포시")
+        .title("축제2")
+        .build();
+    em.persist(festivalTrans2);
+
+    Nana nana = Nana.builder()
+        .version("1")
+        .build();
+    em.persist(nana);
+    NanaTitle nanaTitle = NanaTitle.builder()
+        .imageFile(imageFile1)
+        .heading("heading")
+        .subHeading("subHeading")
+        .language(language)
+        .nana(nana)
+        .build();
+    em.persist(nanaTitle);
+
+    /**
+     * WHEN
+     */
+    LikeToggleDto festivalLikeToggleDto = new LikeToggleDto();
+    festivalLikeToggleDto.setCategory(CategoryContent.FESTIVAL.name());
+    festivalLikeToggleDto.setId(festival1.getId());
+    favoriteService.toggleLikeStatus(memberInfoDto, festivalLikeToggleDto);
+    festivalLikeToggleDto.setId(festival2.getId());
+    favoriteService.toggleLikeStatus(memberInfoDto, festivalLikeToggleDto);
+
+    LikeToggleDto nanaLikeToggleDto = new LikeToggleDto();
+    nanaLikeToggleDto.setCategory(CategoryContent.NANA.name());
+    nanaLikeToggleDto.setId(nana.getId());
+    favoriteService.toggleLikeStatus(memberInfoDto, nanaLikeToggleDto);
+
+    AllCategoryDto allFavoriteList = favoriteService.getAllFavoriteList(memberInfoDto, 0, 12);
+    FestivalDto festivalFavoriteList = favoriteService.getFestivalFavoriteList(memberInfoDto, 0,
+        12);
+    NanaDto nanaFavoriteList = favoriteService.getNanaFavoriteList(memberInfoDto, 0, 12);
+
+    /**
+     * THEN
+     */
+    assertThat(allFavoriteList.getTotalElements()).isEqualTo(3);
+    assertThat(festivalFavoriteList.getTotalElements()).isEqualTo(2);
+    assertThat(nanaFavoriteList.getTotalElements()).isEqualTo(1);
+
+    // 최근에 좋아요한 순서대로 표시
+    assertThat(festivalFavoriteList.getData()).extracting("title")
+        .containsExactly("축제2", "축제1");
+  }
+}


### PR DESCRIPTION
## 📝 Description
- FavoriteRepositoryImpl 각 쿼리에서 category 비교 where문 추가
- FavoriteRepositoryImpl 의 `find{ ... }ThumbnailByPostId` 에서 해당 카테고리의 id와 favorite의 postId 가 동일한지 체크
- 좋이요 요청 토글 {id} pathvariable 삭제
- FavoriteService테스트 코드 작성
  
<br>

## 💬 To Reviewers
- FestivalTrans 의 fee 필드 ` @Column(columnDefinition = "VARCHAR(1024)")` 추가
- nana 테이블의 id를 Favorite의 postId로 사용하도록 통일

<br>

## ☑️ Related Issue
- close #101 
