### PR TITLE
[Docs] refreshToken hidden 처리

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
 import com.jeju.nanaland.global.jwt.dto.JwtResponseDto.JwtDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -56,7 +57,8 @@ public class MemberController {
     return BaseResponse.success(LOGIN_SUCCESS, jwtDto);
   }
 
-  @Operation(summary = "AccessToken 재발급", description = "RefreshToken으로 AccessToken이 재발급됩니다.")
+  @Operation(summary = "AccessToken 재발급", description = "RefreshToken으로 AccessToken이 재발급됩니다."
+      + "header에 AccessToken이 아닌 RefreshToken을 담아 요청해주세요.")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
       @ApiResponse(responseCode = "400", description = "존재하지 않는 회원인 경우", content = @Content),
@@ -64,6 +66,7 @@ public class MemberController {
   })
   @GetMapping("/reissue")
   public BaseResponse<String> reissue(
+      @Parameter(name = "refreshToken", hidden = true)
       @RequestHeader(HttpHeaders.AUTHORIZATION) String refreshToken) {
     String newAccessToken = memberLoginService.reissue(refreshToken);
     return BaseResponse.success(ACCESS_TOKEN_SUCCESS, newAccessToken);


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- swagger 문서에서 refreshToken 재발행 api에서 Authorization에 토큰을 담는 입력 칸이 동작하지 않음
- swagger config를 통해 설정해준 swagger 문서 내의 Authroize 기능을 통해 refreshToken을 담아 요청하면 잘 동작하기 때문에,  해당 입력칸이 보여지지 않도록 hidden 처리함

<br>

## 💬 To Reviewers
- [ ]

<br>

## ☑️ Related Issue
> 관련 이슈
