### PR TITLE
[#61] feat: festival onGoing 필드 업데이트 메서드, 매일 자정 종료된 축제 체크 스케쥴러 생성

### DIFF
--- a/src/main/java/com/jeju/nanaland/NanalandApplication.java
+++ b/src/main/java/com/jeju/nanaland/NanalandApplication.java
@@ -3,13 +3,15 @@ package com.jeju.nanaland;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class NanalandApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(NanalandApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(NanalandApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/entity/Festival.java
@@ -43,4 +43,8 @@ public class Festival extends Common {
     this.festivalTrans = new ArrayList<>();
     this.onGoing = onGoing;
   }
+
+  public void updateOnGoing(boolean onGoing) {
+    this.onGoing = onGoing;
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepository.java
@@ -1,9 +1,12 @@
 package com.jeju.nanaland.domain.festival.repository;
 
 import com.jeju.nanaland.domain.festival.entity.Festival;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long>,
     FestivalRepositoryCustom {
 
+  List<Festival> findAllByOnGoingAndEndDateBefore(boolean onGoing, LocalDate localDate);
 }


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 전체 엔티티에 status 필트 추가한 후 festival에 2년이 지나면 status false 만드는 메서드 추가 예정입니다.
-  매일 정각에 종료된 축제 업데이트하는 메서드 작업 완료
-

<br>

## 💬 To Reviewers
- [ ] status 추가 후 festival 마무리 예정입니다.

<br>

## ☑️ Related Issue
> 관련 이슈
