### PR TITLE
[Refactor] 검색 범위 수정

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
@@ -9,6 +9,6 @@ public interface ExperienceRepositoryCustom {
 
   ExperienceCompositeDto findCompositeDtoById(Long id, Locale locale);
 
-  Page<ExperienceCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  Page<ExperienceCompositeDto> searchCompositeDtoByKeyword(String Keyword, Locale locale,
       Pageable pageable);
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
@@ -48,7 +48,7 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
   }
 
   @Override
-  public Page<ExperienceCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  public Page<ExperienceCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
     List<ExperienceCompositeDto> resultDto = queryFactory
         .select(new QExperienceCompositeDto(
@@ -70,8 +70,10 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
         .from(experience)
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experience.experienceTrans, experienceTrans)
-        .where(experienceTrans.title.contains(title)
-            .and(experienceTrans.language.locale.eq(locale)))
+        .where(experienceTrans.language.locale.eq(locale)
+            .and(experienceTrans.title.contains(keyword)
+                .or(experienceTrans.addressTag.contains(keyword))
+                .or(experienceTrans.content.contains(keyword))))
         .orderBy(experienceTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -82,8 +84,10 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
         .from(experience)
         .leftJoin(experience.imageFile, imageFile)
         .leftJoin(experience.experienceTrans, experienceTrans)
-        .where(experienceTrans.title.contains(title)
-            .and(experienceTrans.language.locale.eq(locale)));
+        .where(experienceTrans.language.locale.eq(locale)
+            .and(experienceTrans.title.contains(keyword)
+                .or(experienceTrans.addressTag.contains(keyword))
+                .or(experienceTrans.content.contains(keyword))));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryCustom.java
@@ -9,6 +9,6 @@ public interface FestivalRepositoryCustom {
 
   FestivalCompositeDto findCompositeDtoById(Long id, Locale locale);
 
-  Page<FestivalCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  Page<FestivalCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable);
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
@@ -4,12 +4,15 @@ import static com.jeju.nanaland.domain.common.entity.QImageFile.imageFile;
 import static com.jeju.nanaland.domain.common.entity.QLanguage.language;
 import static com.jeju.nanaland.domain.festival.entity.QFestival.festival;
 import static com.jeju.nanaland.domain.festival.entity.QFestivalTrans.festivalTrans;
+import static com.jeju.nanaland.domain.hashtag.entity.QHashtag.hashtag;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.festival.dto.FestivalCompositeDto;
 import com.jeju.nanaland.domain.festival.dto.QFestivalCompositeDto;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -53,6 +56,8 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
   public Page<FestivalCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
 
+    List<Long> idListContainAllHashtags = getIdListContainAllHashtags(keyword, locale);
+
     List<FestivalCompositeDto> resultDto = queryFactory
         .select(new QFestivalCompositeDto(
             festival.id,
@@ -60,7 +65,7 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
             imageFile.thumbnailUrl,
             festival.contact,
             festival.homepage,
-            language.locale,
+            festivalTrans.language.locale,
             festivalTrans.title,
             festivalTrans.content,
             festivalTrans.address,
@@ -75,10 +80,11 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
         .from(festival)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festival.festivalTrans, festivalTrans)
-        .where(festivalTrans.language.locale.eq(locale)
-            .and(festivalTrans.title.contains(keyword)
-                .or(festivalTrans.addressTag.contains(keyword))
-                .or(festivalTrans.content.contains(keyword))))
+        .on(festivalTrans.language.locale.eq(locale))
+        .where(festivalTrans.title.contains(keyword)
+            .or(festivalTrans.addressTag.contains(keyword))
+            .or(festivalTrans.content.contains(keyword))
+            .or(festival.id.in(idListContainAllHashtags)))
         .orderBy(festivalTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -89,11 +95,36 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
         .from(festival)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festival.festivalTrans, festivalTrans)
-        .where(festivalTrans.language.locale.eq(locale)
-            .and(festivalTrans.title.contains(keyword)
-                .or(festivalTrans.addressTag.contains(keyword))
-                .or(festivalTrans.content.contains(keyword))));
+        .on(festivalTrans.language.locale.eq(locale))
+        .where(festivalTrans.title.contains(keyword)
+            .or(festivalTrans.addressTag.contains(keyword))
+            .or(festivalTrans.content.contains(keyword))
+            .or(festival.id.in(idListContainAllHashtags)));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
+  }
+
+  private List<Long> getIdListContainAllHashtags(String keyword, Locale locale) {
+    return queryFactory
+        .select(festival.id)
+        .from(festival)
+        .leftJoin(hashtag)
+        .on(hashtag.postId.eq(festival.id)
+            .and(hashtag.category.content.eq(CategoryContent.FESTIVAL))
+            .and(hashtag.language.locale.eq(locale)))
+        .where(hashtag.keyword.content.in(splitKeyword(keyword)))
+        .groupBy(festival.id)
+        .having(festival.id.count().eq(splitKeyword(keyword).stream().count()))
+        .fetch();
+  }
+
+  private List<String> splitKeyword(String keyword) {
+    String[] tokens = keyword.split("\\s+");
+    List<String> tokenList = new ArrayList<>();
+
+    for (String token : tokens) {
+      tokenList.add(token.trim());
+    }
+    return tokenList;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
@@ -47,7 +47,7 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
   }
 
   @Override
-  public Page<FestivalCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  public Page<FestivalCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
 
     List<FestivalCompositeDto> resultDto = queryFactory
@@ -69,8 +69,10 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
         .from(festival)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festival.festivalTrans, festivalTrans)
-        .where(festivalTrans.title.contains(title)
-            .and(festivalTrans.language.locale.eq(locale)))
+        .where(festivalTrans.language.locale.eq(locale)
+            .and(festivalTrans.title.contains(keyword)
+                .or(festivalTrans.addressTag.contains(keyword))
+                .or(festivalTrans.content.contains(keyword))))
         .orderBy(festivalTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -81,8 +83,10 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
         .from(festival)
         .leftJoin(festival.imageFile, imageFile)
         .leftJoin(festival.festivalTrans, festivalTrans)
-        .where(festivalTrans.title.contains(title)
-            .and(festivalTrans.language.locale.eq(locale)));
+        .where(festivalTrans.language.locale.eq(locale)
+            .and(festivalTrans.title.contains(keyword)
+                .or(festivalTrans.addressTag.contains(keyword))
+                .or(festivalTrans.content.contains(keyword))));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
@@ -13,6 +13,6 @@ public interface MarketRepositoryCustom {
   Page<MarketCompositeDto> findMarketThumbnails(Locale locale, List<String> addressFilterList,
       Pageable pageable);
 
-  Page<MarketCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  Page<MarketCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable);
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
@@ -88,7 +88,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
   }
 
   @Override
-  public Page<MarketCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  public Page<MarketCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
     List<MarketCompositeDto> resultDto = queryFactory
         .select(new QMarketCompositeDto(
@@ -109,8 +109,10 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         .from(market)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(market.marketTrans, marketTrans)
-        .where(marketTrans.title.contains(title)
-            .and(marketTrans.language.locale.eq(locale)))
+        .where(marketTrans.language.locale.eq(locale)
+            .and(marketTrans.title.contains(keyword)
+                .or(marketTrans.addressTag.contains(keyword))
+                .or(marketTrans.content.contains(keyword))))
         .orderBy(marketTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -120,8 +122,10 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         .select(market.count())
         .from(market)
         .leftJoin(market.marketTrans, marketTrans)
-        .where(marketTrans.title.contains(title)
-            .and(marketTrans.language.locale.eq(locale)));
+        .where(marketTrans.language.locale.eq(locale)
+            .and(marketTrans.title.contains(keyword)
+                .or(marketTrans.addressTag.contains(keyword))
+                .or(marketTrans.content.contains(keyword))));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
@@ -2,15 +2,18 @@ package com.jeju.nanaland.domain.market.repository;
 
 import static com.jeju.nanaland.domain.common.entity.QImageFile.imageFile;
 import static com.jeju.nanaland.domain.common.entity.QLanguage.language;
+import static com.jeju.nanaland.domain.hashtag.entity.QHashtag.hashtag;
 import static com.jeju.nanaland.domain.market.entity.QMarket.market;
 import static com.jeju.nanaland.domain.market.entity.QMarketTrans.marketTrans;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
 import com.jeju.nanaland.domain.market.dto.QMarketCompositeDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -90,6 +93,9 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
   @Override
   public Page<MarketCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
+
+    List<Long> idListContainAllHashtags = getIdListContainAllHashtags(keyword, locale);
+
     List<MarketCompositeDto> resultDto = queryFactory
         .select(new QMarketCompositeDto(
             market.id,
@@ -97,7 +103,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
             imageFile.thumbnailUrl,
             market.contact,
             market.homepage,
-            language.locale,
+            marketTrans.language.locale,
             marketTrans.title,
             marketTrans.content,
             marketTrans.address,
@@ -109,10 +115,11 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         .from(market)
         .leftJoin(market.imageFile, imageFile)
         .leftJoin(market.marketTrans, marketTrans)
-        .where(marketTrans.language.locale.eq(locale)
-            .and(marketTrans.title.contains(keyword)
-                .or(marketTrans.addressTag.contains(keyword))
-                .or(marketTrans.content.contains(keyword))))
+        .on(marketTrans.language.locale.eq(locale))
+        .where(marketTrans.title.contains(keyword)
+            .or(marketTrans.addressTag.contains(keyword))
+            .or(marketTrans.content.contains(keyword))
+            .or(market.id.in(idListContainAllHashtags)))
         .orderBy(marketTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -121,13 +128,39 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     JPAQuery<Long> countQuery = queryFactory
         .select(market.count())
         .from(market)
+        .leftJoin(market.imageFile, imageFile)
         .leftJoin(market.marketTrans, marketTrans)
-        .where(marketTrans.language.locale.eq(locale)
-            .and(marketTrans.title.contains(keyword)
-                .or(marketTrans.addressTag.contains(keyword))
-                .or(marketTrans.content.contains(keyword))));
+        .on(marketTrans.language.locale.eq(locale))
+        .where(marketTrans.title.contains(keyword)
+            .or(marketTrans.addressTag.contains(keyword))
+            .or(marketTrans.content.contains(keyword))
+            .or(market.id.in(idListContainAllHashtags)));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
+  }
+
+  private List<Long> getIdListContainAllHashtags(String keyword, Locale locale) {
+    return queryFactory
+        .select(market.id)
+        .from(market)
+        .leftJoin(hashtag)
+        .on(hashtag.postId.eq(market.id)
+            .and(hashtag.category.content.eq(CategoryContent.MARKET))
+            .and(hashtag.language.locale.eq(locale)))
+        .where(hashtag.keyword.content.in(splitKeyword(keyword)))
+        .groupBy(market.id)
+        .having(market.id.count().eq(splitKeyword(keyword).stream().count()))
+        .fetch();
+  }
+
+  private List<String> splitKeyword(String keyword) {
+    String[] tokens = keyword.split("\\s+");
+    List<String> tokenList = new ArrayList<>();
+
+    for (String token : tokens) {
+      tokenList.add(token.trim());
+    }
+    return tokenList;
   }
 
   private BooleanExpression addressTagCondition(List<String> addressFilterList) {

--- a/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryCustom.java
@@ -16,4 +16,7 @@ public interface NanaRepositoryCustom {
   Page<NanaThumbnail> findAllNanaThumbnailDto(Locale locale, Pageable pageable);
   //이거 좀 어렵군요...
 //  NanaResponse.nanaDetailDto findNanaDetailById(Long id, Locale locale);
+
+  Page<NanaThumbnail> searchNanaThumbnailDtoByKeyword(String keyword, Locale locale,
+      Pageable pageable);
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryImpl.java
@@ -75,15 +75,15 @@ public class NanaRepositoryImpl implements NanaRepositoryCustom {
   public Page<NanaThumbnail> searchNanaThumbnailDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
     List<NanaThumbnail> resultDto = queryFactory.select(new QNanaResponse_NanaThumbnail(
-            nanaTitle.id,
+            nana.id,
             imageFile.thumbnailUrl,
             nana.version,
             nanaTitle.heading,
             nanaTitle.subHeading
         ))
-        .from(nanaTitle)
+        .from(nana)
         .leftJoin(nanaTitle.nana, nana)
-        .join(nanaContent).on(nanaContent.nanaTitle.eq(nanaTitle))
+        .leftJoin(nanaContent).on(nanaContent.nanaTitle.eq(nanaTitle))
         .leftJoin(nanaTitle.imageFile, imageFile)
         .where(nanaTitle.language.locale.eq(locale)
             .and(nanaTitle.heading.contains(keyword)

--- a/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.nana.repository;
 
 import static com.jeju.nanaland.domain.common.entity.QImageFile.imageFile;
 import static com.jeju.nanaland.domain.nana.entity.QNana.nana;
+import static com.jeju.nanaland.domain.nana.entity.QNanaContent.nanaContent;
 import static com.jeju.nanaland.domain.nana.entity.QNanaTitle.nanaTitle;
 
 import com.jeju.nanaland.domain.common.entity.Locale;
@@ -66,6 +67,41 @@ public class NanaRepositoryImpl implements NanaRepositoryCustom {
         .leftJoin(nanaTitle.nana, nana)
         .leftJoin(nanaTitle.imageFile, imageFile)
         .where((nanaTitle.language.locale.eq(locale)));
+
+    return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
+  }
+
+  @Override
+  public Page<NanaThumbnail> searchNanaThumbnailDtoByKeyword(String keyword, Locale locale,
+      Pageable pageable) {
+    List<NanaThumbnail> resultDto = queryFactory.select(new QNanaResponse_NanaThumbnail(
+            nanaTitle.id,
+            imageFile.thumbnailUrl,
+            nana.version,
+            nanaTitle.heading,
+            nanaTitle.subHeading
+        ))
+        .from(nanaTitle)
+        .leftJoin(nanaTitle.nana, nana)
+        .join(nanaContent).on(nanaContent.nanaTitle.eq(nanaTitle))
+        .leftJoin(nanaTitle.imageFile, imageFile)
+        .where(nanaTitle.language.locale.eq(locale)
+            .and(nanaTitle.heading.contains(keyword)
+                .or(nanaContent.subTitle.contains(keyword))))
+        .orderBy(nanaTitle.createdAt.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory
+        .select(nanaTitle.count())
+        .from(nanaTitle)
+        .leftJoin(nanaTitle.nana, nana)
+        .join(nanaContent).on(nanaContent.nanaTitle.eq(nanaTitle))
+        .leftJoin(nanaTitle.imageFile, imageFile)
+        .where(nanaTitle.language.locale.eq(locale)
+            .and(nanaTitle.heading.contains(keyword)
+                .or(nanaContent.subTitle.contains(keyword))));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }

--- a/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryCustom.java
@@ -10,7 +10,7 @@ public interface NatureRepositoryCustom {
 
   NatureCompositeDto findCompositeDtoById(Long id, Locale locale);
 
-  Page<NatureCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  Page<NatureCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable);
 
   Page<NatureCompositeDto> findNatureThumbnails(Locale locale, List<String> addressFilterList,

--- a/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryImpl.java
@@ -2,15 +2,18 @@ package com.jeju.nanaland.domain.nature.repository;
 
 import static com.jeju.nanaland.domain.common.entity.QImageFile.imageFile;
 import static com.jeju.nanaland.domain.common.entity.QLanguage.language;
+import static com.jeju.nanaland.domain.hashtag.entity.QHashtag.hashtag;
 import static com.jeju.nanaland.domain.nature.entity.QNature.nature;
 import static com.jeju.nanaland.domain.nature.entity.QNatureTrans.natureTrans;
 
+import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.nature.dto.NatureCompositeDto;
 import com.jeju.nanaland.domain.nature.dto.QNatureCompositeDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -53,13 +56,16 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
   @Override
   public Page<NatureCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
+
+    List<Long> idListContainAllHashtags = getIdListContainAllHashtags(keyword, locale);
+
     List<NatureCompositeDto> resultDto = queryFactory
         .select(new QNatureCompositeDto(
             nature.id,
             imageFile.originUrl,
             imageFile.thumbnailUrl,
             nature.contact,
-            language.locale,
+            natureTrans.language.locale,
             natureTrans.title,
             natureTrans.content,
             natureTrans.address,
@@ -73,24 +79,26 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
         .from(nature)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(nature.natureTrans, natureTrans)
-        .where(natureTrans.language.locale.eq(locale)
-            .and(natureTrans.title.contains(keyword)
-                .or(natureTrans.addressTag.contains(keyword))
-                .or(natureTrans.content.contains(keyword))))
+        .on(natureTrans.language.locale.eq(locale))
+        .where(natureTrans.title.contains(keyword)
+            .or(natureTrans.addressTag.contains(keyword))
+            .or(natureTrans.content.contains(keyword))
+            .or(nature.id.in(idListContainAllHashtags)))
         .orderBy(natureTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();
 
     JPAQuery<Long> countQuery = queryFactory
-        .select(nature.count())
+        .select(nature.countDistinct())
         .from(nature)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(nature.natureTrans, natureTrans)
-        .where(natureTrans.language.locale.eq(locale)
-            .and(natureTrans.title.contains(keyword)
-                .or(natureTrans.addressTag.contains(keyword))
-                .or(natureTrans.content.contains(keyword))));
+        .on(natureTrans.language.locale.eq(locale))
+        .where(natureTrans.title.contains(keyword)
+            .or(natureTrans.addressTag.contains(keyword))
+            .or(natureTrans.content.contains(keyword))
+            .or(nature.id.in(idListContainAllHashtags)));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }
@@ -141,5 +149,29 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
     } else {
       return natureTrans.addressTag.in(addressFilterList);
     }
+  }
+
+  private List<Long> getIdListContainAllHashtags(String keyword, Locale locale) {
+    return queryFactory
+        .select(nature.id)
+        .from(nature)
+        .leftJoin(hashtag)
+        .on(hashtag.postId.eq(nature.id)
+            .and(hashtag.category.content.eq(CategoryContent.NATURE))
+            .and(hashtag.language.locale.eq(locale)))
+        .where(hashtag.keyword.content.in(splitKeyword(keyword)))
+        .groupBy(nature.id)
+        .having(nature.id.count().eq(splitKeyword(keyword).stream().count()))
+        .fetch();
+  }
+
+  private List<String> splitKeyword(String keyword) {
+    String[] tokens = keyword.split("\\s+");
+    List<String> tokenList = new ArrayList<>();
+
+    for (String token : tokens) {
+      tokenList.add(token.trim());
+    }
+    return tokenList;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryImpl.java
@@ -51,7 +51,7 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
   }
 
   @Override
-  public Page<NatureCompositeDto> searchCompositeDtoByTitle(String title, Locale locale,
+  public Page<NatureCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,
       Pageable pageable) {
     List<NatureCompositeDto> resultDto = queryFactory
         .select(new QNatureCompositeDto(
@@ -73,8 +73,10 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
         .from(nature)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(nature.natureTrans, natureTrans)
-        .where(natureTrans.title.contains(title)
-            .and(natureTrans.language.locale.eq(locale)))
+        .where(natureTrans.language.locale.eq(locale)
+            .and(natureTrans.title.contains(keyword)
+                .or(natureTrans.addressTag.contains(keyword))
+                .or(natureTrans.content.contains(keyword))))
         .orderBy(natureTrans.createdAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -85,9 +87,10 @@ public class NatureRepositoryImpl implements NatureRepositoryCustom {
         .from(nature)
         .leftJoin(nature.imageFile, imageFile)
         .leftJoin(nature.natureTrans, natureTrans)
-        .where(natureTrans.title.contains(title)
-            .and(natureTrans.language.locale.eq(locale))
-        );
+        .where(natureTrans.language.locale.eq(locale)
+            .and(natureTrans.title.contains(keyword)
+                .or(natureTrans.addressTag.contains(keyword))
+                .or(natureTrans.content.contains(keyword))));
 
     return PageableExecutionUtils.getPage(resultDto, pageable, countQuery::fetchOne);
   }

--- a/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
@@ -4,7 +4,8 @@ import static com.jeju.nanaland.global.exception.SuccessCode.SEARCH_SUCCESS;
 
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.search.dto.SearchResponse;
-import com.jeju.nanaland.domain.search.dto.SearchResponse.CategoryDto;
+import com.jeju.nanaland.domain.search.dto.SearchResponse.AllCategoryDto;
+import com.jeju.nanaland.domain.search.dto.SearchResponse.ResultDto;
 import com.jeju.nanaland.domain.search.service.SearchService;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.jwt.AuthMember;
@@ -38,14 +39,13 @@ public class SearchController {
       @ApiResponse(responseCode = "200", description = "성공"),
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
-  @GetMapping("/category")
-  public BaseResponse<CategoryDto> searchCategory(
+  @GetMapping("/all")
+  public BaseResponse<AllCategoryDto> searchCategory(
       @AuthMember MemberInfoDto memberInfoDto,
       @NotNull String keyword) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getCategorySearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale()));
+    SearchResponse.AllCategoryDto result = searchService.searchAllResultDto(memberInfoDto, keyword);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 
   @Operation(
@@ -61,10 +61,8 @@ public class SearchController {
       @NotNull String keyword,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
-
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getNatureSearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale(), page, size));
+    ResultDto result = searchService.searchNatureResultDto(memberInfoDto, keyword, page, size);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 
   @Operation(
@@ -81,9 +79,8 @@ public class SearchController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getFestivalSearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale(), page, size));
+    ResultDto result = searchService.searchFestivalResultDto(memberInfoDto, keyword, page, size);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 
   @Operation(
@@ -100,9 +97,9 @@ public class SearchController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getExperienceSearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale(), page, size));
+    ResultDto result = searchService.searchExperienceResultDto(memberInfoDto, keyword, page,
+        size);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 
   @Operation(
@@ -119,9 +116,8 @@ public class SearchController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getMarketSearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale(), page, size));
+    ResultDto result = searchService.searchMarketResultDto(memberInfoDto, keyword, page, size);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 
   @Operation(
@@ -138,11 +134,10 @@ public class SearchController {
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "12") int size) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getNanaSearchResultDto(memberInfoDto.getMember(), keyword,
-            memberInfoDto.getLanguage().getLocale(), page, size));
+    ResultDto result = searchService.searchNanaResultDto(memberInfoDto, keyword, page, size);
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
-  
+
   @Operation(
       summary = "인기 검색어 조회",
       description = "언어 별로 가장 검색이 많이 된 8개 반환")
@@ -153,7 +148,7 @@ public class SearchController {
   @GetMapping("/popular")
   public BaseResponse<List<String>> getPopularSearch(@AuthMember MemberInfoDto memberInfoDto) {
 
-    return BaseResponse.success(SEARCH_SUCCESS,
-        searchService.getPopularSearch(memberInfoDto.getLanguage().getLocale()));
+    List<String> result = searchService.getPopularSearch(memberInfoDto.getLanguage().getLocale());
+    return BaseResponse.success(SEARCH_SUCCESS, result);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/controller/SearchController.java
@@ -125,6 +125,25 @@ public class SearchController {
   }
 
   @Operation(
+      summary = "나나스픽 검색 결과",
+      description = "나나스픽 검색 결과 반환")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
+  })
+  @GetMapping("/nana")
+  public BaseResponse<SearchResponse.ResultDto> searchNana(
+      @AuthMember MemberInfoDto memberInfoDto,
+      @NotNull String keyword,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "12") int size) {
+
+    return BaseResponse.success(SEARCH_SUCCESS,
+        searchService.getNanaSearchResultDto(memberInfoDto.getMember(), keyword,
+            memberInfoDto.getLanguage().getLocale(), page, size));
+  }
+  
+  @Operation(
       summary = "인기 검색어 조회",
       description = "언어 별로 가장 검색이 많이 된 8개 반환")
   @ApiResponses(value = {

--- a/src/main/java/com/jeju/nanaland/domain/search/dto/SearchResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/dto/SearchResponse.java
@@ -10,7 +10,7 @@ public class SearchResponse {
   @Data
   @Builder
   @Schema
-  public static class CategoryDto {
+  public static class AllCategoryDto {
 
     @Schema(description = "축제 조회 결과")
     private ResultDto festival;
@@ -45,6 +45,9 @@ public class SearchResponse {
 
     @Schema(description = "게시물 id")
     private Long id;
+
+    @Schema(description = "게시물 카테고리")
+    private String category;
 
     @Schema(description = "게시물 썸네일 이미지")
     private String thumbnailUrl;

--- a/src/main/java/com/jeju/nanaland/domain/search/dto/SearchResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/dto/SearchResponse.java
@@ -23,11 +23,9 @@ public class SearchResponse {
 
     @Schema(description = "전통시장 조회 결과")
     private ResultDto market;
-  }
 
-  @Data
-  public static class StoryDto {
-
+    @Schema(description = "나나스픽 조회 결과")
+    private ResultDto nana;
   }
 
   @Data

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -3,6 +3,7 @@ package com.jeju.nanaland.domain.search.service;
 import static com.jeju.nanaland.domain.common.data.CategoryContent.EXPERIENCE;
 import static com.jeju.nanaland.domain.common.data.CategoryContent.FESTIVAL;
 import static com.jeju.nanaland.domain.common.data.CategoryContent.MARKET;
+import static com.jeju.nanaland.domain.common.data.CategoryContent.NANA;
 import static com.jeju.nanaland.domain.common.data.CategoryContent.NATURE;
 
 import com.jeju.nanaland.domain.common.entity.Locale;
@@ -13,6 +14,7 @@ import com.jeju.nanaland.domain.festival.dto.FestivalCompositeDto;
 import com.jeju.nanaland.domain.festival.repository.FestivalRepository;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
 import com.jeju.nanaland.domain.market.repository.MarketRepository;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnail;
 import com.jeju.nanaland.domain.nana.repository.NanaRepository;
@@ -49,27 +51,35 @@ public class SearchService {
 
   private final RedisTemplate<String, String> redisTemplate;
 
-  public SearchResponse.CategoryDto getCategorySearchResultDto(Member member, String keyword,
-      Locale locale) {
+  public SearchResponse.AllCategoryDto searchAllResultDto(MemberInfoDto memberInfoDto,
+      String keyword) {
+
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
+
     // Redis에 해당 검색어 count + 1
     updateSearchCountV1(keyword, locale);
 
     // offset: 0, pageSize: 2
     int page = 0;
     int size = 2;
-    return SearchResponse.CategoryDto.builder()
-        .nature(getNatureSearchResultDto(member, keyword, locale, page, size))
-        .festival(getFestivalSearchResultDto(member, keyword, locale, page, size))
-        .market(getMarketSearchResultDto(member, keyword, locale, page, size))
-        .experience(getExperienceSearchResultDto(member, keyword, locale, page, size))
-        .nana(getNanaSearchResultDto(member, keyword, locale, page, size))
+    return SearchResponse.AllCategoryDto.builder()
+        .nature(searchNatureResultDto(memberInfoDto, keyword, page, size))
+        .festival(searchFestivalResultDto(memberInfoDto, keyword, page, size))
+        .market(searchMarketResultDto(memberInfoDto, keyword, page, size))
+        .experience(searchExperienceResultDto(memberInfoDto, keyword, page, size))
+        .nana(searchNanaResultDto(memberInfoDto, keyword, page, size))
         .build();
   }
 
-  public SearchResponse.ResultDto getNatureSearchResultDto(Member member, String keyword,
-      Locale locale,
-      int page, int size) {
+  public SearchResponse.ResultDto searchNatureResultDto(
+      MemberInfoDto memberInfoDto,
+      String keyword,
+      int page,
+      int size) {
 
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
     Pageable pageable = PageRequest.of(page, size);
     Page<NatureCompositeDto> resultPage = natureRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
@@ -81,6 +91,7 @@ public class SearchService {
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
+              .category(NATURE.name())
               .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
@@ -93,10 +104,14 @@ public class SearchService {
         .build();
   }
 
-  public SearchResponse.ResultDto getFestivalSearchResultDto(Member member, String keyword,
-      Locale locale,
-      int page, int size) {
+  public SearchResponse.ResultDto searchFestivalResultDto(
+      MemberInfoDto memberInfoDto,
+      String keyword,
+      int page,
+      int size) {
 
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
     Pageable pageable = PageRequest.of(page, size);
     Page<FestivalCompositeDto> resultPage = festivalRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
@@ -108,6 +123,7 @@ public class SearchService {
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
+              .category(FESTIVAL.name())
               .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
@@ -120,10 +136,14 @@ public class SearchService {
         .build();
   }
 
-  public SearchResponse.ResultDto getExperienceSearchResultDto(Member member, String keyword,
-      Locale locale,
-      int page, int size) {
+  public SearchResponse.ResultDto searchExperienceResultDto(
+      MemberInfoDto memberInfoDto,
+      String keyword,
+      int page,
+      int size) {
 
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
     Pageable pageable = PageRequest.of(page, size);
     Page<ExperienceCompositeDto> resultPage = experienceRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
@@ -135,6 +155,7 @@ public class SearchService {
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
+              .category(EXPERIENCE.name())
               .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
@@ -147,10 +168,14 @@ public class SearchService {
         .build();
   }
 
-  public SearchResponse.ResultDto getMarketSearchResultDto(Member member, String keyword,
-      Locale locale,
-      int page, int size) {
+  public SearchResponse.ResultDto searchMarketResultDto(
+      MemberInfoDto memberInfoDto,
+      String keyword,
+      int page,
+      int size) {
 
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
     Pageable pageable = PageRequest.of(page, size);
     Page<MarketCompositeDto> resultPage = marketRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
@@ -162,6 +187,7 @@ public class SearchService {
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
+              .category(MARKET.name())
               .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
@@ -174,10 +200,14 @@ public class SearchService {
         .build();
   }
 
-  public SearchResponse.ResultDto getNanaSearchResultDto(Member member, String keyword,
-      Locale locale,
-      int page, int size) {
+  public SearchResponse.ResultDto searchNanaResultDto(
+      MemberInfoDto memberInfoDto,
+      String keyword,
+      int page,
+      int size) {
 
+    Locale locale = memberInfoDto.getLanguage().getLocale();
+    Member member = memberInfoDto.getMember();
     Pageable pageable = PageRequest.of(page, size);
     Page<NanaThumbnail> resultPage = nanaRepository.searchNanaThumbnailDtoByKeyword(
         keyword, locale, pageable);
@@ -189,6 +219,7 @@ public class SearchService {
       thumbnails.add(
           ThumbnailDto.builder()
               .id(thumbnail.getId())
+              .category(NANA.name())
               .thumbnailUrl(thumbnail.getThumbnailUrl())
               .title(thumbnail.getHeading())
               .isFavorite(favoriteIds.contains(thumbnail.getId()))

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -67,7 +67,7 @@ public class SearchService {
       int page, int size) {
 
     Pageable pageable = PageRequest.of(page, size);
-    Page<NatureCompositeDto> resultPage = natureRepository.searchCompositeDtoByTitle(
+    Page<NatureCompositeDto> resultPage = natureRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
     List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, NATURE);
@@ -94,7 +94,7 @@ public class SearchService {
       int page, int size) {
 
     Pageable pageable = PageRequest.of(page, size);
-    Page<FestivalCompositeDto> resultPage = festivalRepository.searchCompositeDtoByTitle(
+    Page<FestivalCompositeDto> resultPage = festivalRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
     List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, FESTIVAL);
@@ -121,7 +121,7 @@ public class SearchService {
       int page, int size) {
 
     Pageable pageable = PageRequest.of(page, size);
-    Page<ExperienceCompositeDto> resultPage = experienceRepository.searchCompositeDtoByTitle(
+    Page<ExperienceCompositeDto> resultPage = experienceRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
     List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, EXPERIENCE);
@@ -148,7 +148,7 @@ public class SearchService {
       int page, int size) {
 
     Pageable pageable = PageRequest.of(page, size);
-    Page<MarketCompositeDto> resultPage = marketRepository.searchCompositeDtoByTitle(
+    Page<MarketCompositeDto> resultPage = marketRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
     List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, MARKET);

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -14,6 +14,8 @@ import com.jeju.nanaland.domain.festival.repository.FestivalRepository;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
 import com.jeju.nanaland.domain.market.repository.MarketRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnail;
+import com.jeju.nanaland.domain.nana.repository.NanaRepository;
 import com.jeju.nanaland.domain.nature.dto.NatureCompositeDto;
 import com.jeju.nanaland.domain.nature.repository.NatureRepository;
 import com.jeju.nanaland.domain.search.dto.SearchResponse;
@@ -41,6 +43,7 @@ public class SearchService {
   private final ExperienceRepository experienceRepository;
   private final MarketRepository marketRepository;
   private final FestivalRepository festivalRepository;
+  private final NanaRepository nanaRepository;
 
   private final FavoriteService favoriteService;
 
@@ -59,6 +62,7 @@ public class SearchService {
         .festival(getFestivalSearchResultDto(member, keyword, locale, page, size))
         .market(getMarketSearchResultDto(member, keyword, locale, page, size))
         .experience(getExperienceSearchResultDto(member, keyword, locale, page, size))
+        .nana(getNanaSearchResultDto(member, keyword, locale, page, size))
         .build();
   }
 
@@ -161,6 +165,33 @@ public class SearchService {
               .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
+              .build());
+    }
+
+    return SearchResponse.ResultDto.builder()
+        .totalElements(resultPage.getTotalElements())
+        .data(thumbnails)
+        .build();
+  }
+
+  public SearchResponse.ResultDto getNanaSearchResultDto(Member member, String keyword,
+      Locale locale,
+      int page, int size) {
+
+    Pageable pageable = PageRequest.of(page, size);
+    Page<NanaThumbnail> resultPage = nanaRepository.searchNanaThumbnailDtoByKeyword(
+        keyword, locale, pageable);
+
+    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, MARKET);
+
+    List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
+    for (NanaThumbnail thumbnail : resultPage) {
+      thumbnails.add(
+          ThumbnailDto.builder()
+              .id(thumbnail.getId())
+              .thumbnailUrl(thumbnail.getThumbnailUrl())
+              .title(thumbnail.getHeading())
+              .isFavorite(favoriteIds.contains(thumbnail.getId()))
               .build());
     }
 

--- a/src/test/java/com/jeju/nanaland/config/TestConfig.java
+++ b/src/test/java/com/jeju/nanaland/config/TestConfig.java
@@ -1,0 +1,19 @@
+package com.jeju.nanaland.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.experience.repository;
+
+import com.jeju.nanaland.config.TestConfig;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(TestConfig.class)
+class ExperienceRepositoryTest {
+
+  @Autowired
+  ExperienceRepository experienceRepository;
+
+  @Test
+  @DisplayName("이색체험 검색")
+  void searchExperienceTest() {
+    Pageable pageable = PageRequest.of(0, 12);
+    experienceRepository.searchCompositeDtoByKeyword("쇼핑", Locale.KOREAN, pageable);
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
@@ -162,26 +162,24 @@ class FavoriteServiceTest {
      */
     Festival festival1 = Festival.builder()
         .imageFile(imageFile1)
-        .season("봄")
+        .season("spring") // TODO: Test DB 한글 설정
         .build();
     em.persist(festival1);
     FestivalTrans festivalTrans1 = FestivalTrans.builder()
         .festival(festival1)
         .language(language)
-        .addressTag("제주시")
-        .title("축제1")
+        .title("festival1")
         .build();
     em.persist(festivalTrans1);
     Festival festival2 = Festival.builder()
         .imageFile(imageFile2)
-        .season("여름")
+        .season("summer")
         .build();
     em.persist(festival2);
     FestivalTrans festivalTrans2 = FestivalTrans.builder()
         .festival(festival2)
         .language(language)
-        .addressTag("서귀포시")
-        .title("축제2")
+        .title("festival2")
         .build();
     em.persist(festivalTrans2);
 
@@ -227,6 +225,6 @@ class FavoriteServiceTest {
 
     // 최근에 좋아요한 순서대로 표시
     assertThat(festivalFavoriteList.getData()).extracting("title")
-        .containsExactly("축제2", "축제1");
+        .containsExactly("festival2", "festival1");
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.festival.repository;
+
+import com.jeju.nanaland.config.TestConfig;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(TestConfig.class)
+class FestivalRepositoryTest {
+
+  @Autowired
+  FestivalRepository festivalRepository;
+
+  @Test
+  @DisplayName("축제 검색")
+  void searchFestivalTest() {
+    Pageable pageable = PageRequest.of(0, 12);
+    festivalRepository.searchCompositeDtoByKeyword("쇼핑", Locale.KOREAN, pageable);
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryTest.java
@@ -1,0 +1,26 @@
+package com.jeju.nanaland.domain.market.repository;
+
+import com.jeju.nanaland.config.TestConfig;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(TestConfig.class)
+class MarketRepositoryTest {
+
+  @Autowired
+  MarketRepository marketRepository;
+
+  @Test
+  @DisplayName("전통시장 검색")
+  void searchMarketTest() {
+    Pageable pageable = PageRequest.of(0, 12);
+    marketRepository.searchCompositeDtoByKeyword("쇼핑", Locale.KOREAN, pageable);
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.jeju.nanaland.domain.nature.repository;
+
+import com.jeju.nanaland.config.TestConfig;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.nature.dto.NatureCompositeDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(TestConfig.class)
+class NatureRepositoryTest {
+
+  @Autowired
+  NatureRepository natureRepository;
+
+  @Test
+  @DisplayName("7대자연 검색")
+  void searchNatureTest() {
+    Pageable pageable = PageRequest.of(0, 12);
+    Page<NatureCompositeDto> result = natureRepository.searchCompositeDtoByKeyword("자연경관",
+        Locale.KOREAN,
+        pageable);
+  }
+}

--- a/src/test/java/com/jeju/nanaland/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/search/service/SearchServiceTest.java
@@ -10,6 +10,7 @@ import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
 import com.jeju.nanaland.domain.market.entity.Market;
 import com.jeju.nanaland.domain.market.entity.MarketTrans;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import com.jeju.nanaland.domain.search.dto.SearchResponse.ResultDto;
@@ -35,6 +36,7 @@ class SearchServiceTest {
   Member member;
   ImageFile imageFile1, imageFile2;
   Category category;
+  MemberInfoDto memberInfoDto;
 
   @BeforeEach
   void init() {
@@ -64,6 +66,11 @@ class SearchServiceTest {
         .profileImageFile(imageFile1)
         .build();
     em.persist(member);
+
+    memberInfoDto = MemberInfoDto.builder()
+        .language(language)
+        .member(member)
+        .build();
 
     category = Category.builder()
         .content(CategoryContent.MARKET)
@@ -108,9 +115,9 @@ class SearchServiceTest {
      * result2 : keyword = title1
      */
     ResultDto result1 =
-        searchService.getMarketSearchResultDto(member, "title", Locale.KOREAN, 0, 4);
+        searchService.searchMarketResultDto(memberInfoDto, "title", 0, 4);
     ResultDto result2 =
-        searchService.getMarketSearchResultDto(member, "title1", Locale.KOREAN, 0, 4);
+        searchService.searchMarketResultDto(memberInfoDto, "title1", 0, 4);
 
     /**
      * THEN


### PR DESCRIPTION
## 📝 Description
- NANA를 제외한 카테고리 검색 범위 수정
  - 제목에 포함
  - 본문에 포함
  - 위치태그와 일치
  - 공백을 기준으로 분리했을때 해당 해시태그들이 게시물의 해시태그 리스트에 모두 포함될때

<br>

## 💬 To Reviewers
- 아직 NANA쪽 기능 구현이 덜 된것 같아서, 해당 기능 구현 완료되면 NANA 검색도 수정하겠습니다.
- searchController에서 모든 카테고리 조회를 favorite과 통일성 있게 하기 위해서 엔드포인트를 search/all로 바꿨습니다.

<br>

## ☑️ Related Issue
- close #99 
