### PR TITLE
[Feat] 이용약관 동의 여부 저장 구현

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import com.jeju.nanaland.domain.member.service.MemberConsentService;
 import com.jeju.nanaland.domain.member.service.MemberLoginService;
 import com.jeju.nanaland.domain.member.service.MemberTypeService;
 import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.exception.SuccessCode;
 import com.jeju.nanaland.global.jwt.AuthMember;
 import com.jeju.nanaland.global.jwt.dto.JwtResponseDto.JwtDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +29,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -76,12 +76,18 @@ public class MemberController {
     return BaseResponse.success(ACCESS_TOKEN_SUCCESS, newAccessToken);
   }
 
+  @Operation(summary = "이용약관 동의 여부", description = "회원의 이용약관 동의 여부를 업데이트합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "401", description = "RefreshToken이 유효하지 않은 경우", content = @Content)
+  })
   @PostMapping("/consent")
-  public ResponseEntity updateConsent(
+  public BaseResponse<Null> updateConsent(
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid MemberConsentDTO memberConsentDTO) {
     memberConsentService.updateConsent(memberInfoDto, memberConsentDTO);
-    return ResponseEntity.ok().build();
+    return BaseResponse.success(SuccessCode.CONSENT_UPDATE_SUCCESS);
   }
 
   @Operation(

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -7,8 +7,10 @@ import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_TYPE_
 
 import com.jeju.nanaland.domain.member.dto.MemberRequest;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
+import com.jeju.nanaland.domain.member.dto.MemberRequest.MemberConsentDTO;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.RecommendPostDto;
+import com.jeju.nanaland.domain.member.service.MemberConsentService;
 import com.jeju.nanaland.domain.member.service.MemberLoginService;
 import com.jeju.nanaland.domain.member.service.MemberTypeService;
 import com.jeju.nanaland.global.BaseResponse;
@@ -26,6 +28,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,6 +46,7 @@ public class MemberController {
 
   private final MemberLoginService memberLoginService;
   private final MemberTypeService memberTypeService;
+  private final MemberConsentService memberConsentService;
 
 
   @Operation(summary = "로그인", description = "로그인을 하면 JWT가 발급됩니다.")
@@ -70,6 +74,14 @@ public class MemberController {
       @RequestHeader(HttpHeaders.AUTHORIZATION) String refreshToken) {
     String newAccessToken = memberLoginService.reissue(refreshToken);
     return BaseResponse.success(ACCESS_TOKEN_SUCCESS, newAccessToken);
+  }
+
+  @PostMapping("/consent")
+  public ResponseEntity updateConsent(
+      @AuthMember MemberInfoDto memberInfoDto,
+      @RequestBody @Valid MemberConsentDTO memberConsentDTO) {
+    memberConsentService.updateConsent(memberInfoDto, memberConsentDTO);
+    return ResponseEntity.ok().build();
   }
 
   @Operation(

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.member.dto;
 
 import com.jeju.nanaland.domain.common.annotation.EnumValid;
 import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.member.entity.ConsentType;
 import com.jeju.nanaland.domain.member.entity.MemberType;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,6 +10,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Data;
 import lombok.Getter;
 
@@ -50,6 +52,30 @@ public class MemberRequest {
     @Schema(description = "소셜 로그인 Provider ID", example = "1234567890")
     @NotNull
     private Long providerId;
+  }
+
+  @Data
+  @Schema(description = "이용약관 동의 요청 DTO")
+  public static class MemberConsentDTO {
+
+    @Schema(description = "이용약관 동의 여부")
+    List<ConsentItem> consentItems;
+  }
+
+  @Getter
+  public static class ConsentItem {
+
+    @Schema(description = "이용약관", example = "TERMS_OF_USE",
+        allowableValues = {"TERMS_OF_USE", "MARKETING", "LOCATION_SERVICE"})
+    @NotNull
+    @EnumValid(
+        enumClass = ConsentType.class,
+        message = "ConsentType이 유효하지 않습니다."
+    )
+    private String consentType;
+
+    @Schema(description = "동의 여부", defaultValue = "false")
+    private Boolean consent;
   }
 
   @Data

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -6,6 +6,7 @@ import com.jeju.nanaland.domain.member.entity.ConsentType;
 import com.jeju.nanaland.domain.member.entity.MemberType;
 import com.jeju.nanaland.domain.member.entity.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -59,6 +60,7 @@ public class MemberRequest {
   public static class MemberConsentDTO {
 
     @Schema(description = "이용약관 동의 여부")
+    @Valid
     List<ConsentItem> consentItems;
   }
 
@@ -75,6 +77,7 @@ public class MemberRequest {
     private String consentType;
 
     @Schema(description = "동의 여부", defaultValue = "false")
+    @NotNull
     private Boolean consent;
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/ConsentType.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/ConsentType.java
@@ -1,0 +1,5 @@
+package com.jeju.nanaland.domain.member.entity;
+
+public enum ConsentType {
+  TERMS_OF_USE, MARKETING, LOCATION_SERVICE
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsent.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsent.java
@@ -34,11 +34,15 @@ public class MemberConsent extends BaseEntity {
   private LocalDateTime consentDate;
 
   @Builder
-  public MemberConsent(Member member, ConsentType consentType, boolean consent,
-      LocalDateTime consentDate) {
+  public MemberConsent(Member member, ConsentType consentType, boolean consent) {
     this.member = member;
     this.consentType = consentType;
     this.consent = consent;
-    this.consentDate = consentDate;
+    this.consentDate = consent ? LocalDateTime.now() : null;
+  }
+
+  public void updateConsent(boolean consent) {
+    this.consent = consent;
+    this.consentDate = consent ? LocalDateTime.now() : null;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsent.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsent.java
@@ -4,6 +4,10 @@ import com.jeju.nanaland.domain.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -13,17 +17,26 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberConsents extends BaseEntity {
+public class MemberConsent extends BaseEntity {
 
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @NotNull
   @Enumerated(EnumType.STRING)
   private ConsentType consentType;
 
+  @NotNull
   private boolean consent;
 
   private LocalDateTime consentDate;
 
   @Builder
-  public MemberConsents(ConsentType consentType, boolean consent, LocalDateTime consentDate) {
+  public MemberConsent(Member member, ConsentType consentType, boolean consent,
+      LocalDateTime consentDate) {
+    this.member = member;
     this.consentType = consentType;
     this.consent = consent;
     this.consentDate = consentDate;

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsents.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberConsents.java
@@ -1,0 +1,31 @@
+package com.jeju.nanaland.domain.member.entity;
+
+import com.jeju.nanaland.domain.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberConsents extends BaseEntity {
+
+  @Enumerated(EnumType.STRING)
+  private ConsentType consentType;
+
+  private boolean consent;
+
+  private LocalDateTime consentDate;
+
+  @Builder
+  public MemberConsents(ConsentType consentType, boolean consent, LocalDateTime consentDate) {
+    this.consentType = consentType;
+    this.consent = consent;
+    this.consentDate = consentDate;
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/Provider.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/Provider.java
@@ -1,5 +1,5 @@
 package com.jeju.nanaland.domain.member.entity;
 
 public enum Provider {
-  KAKAO, GOOGLE, APPLE
+  KAKAO, GOOGLE, APPLE, GUEST
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberConsentRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberConsentRepository.java
@@ -1,8 +1,12 @@
 package com.jeju.nanaland.domain.member.repository;
 
+import com.jeju.nanaland.domain.member.entity.ConsentType;
+import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.MemberConsent;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberConsentRepository extends JpaRepository<MemberConsent, Long> {
 
+  Optional<MemberConsent> findByConsentTypeAndMember(ConsentType consentType, Member member);
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberConsentRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberConsentRepository.java
@@ -1,0 +1,8 @@
+package com.jeju.nanaland.domain.member.repository;
+
+import com.jeju.nanaland.domain.member.entity.MemberConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberConsentRepository extends JpaRepository<MemberConsent, Long> {
+
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberConsentService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberConsentService.java
@@ -1,0 +1,29 @@
+package com.jeju.nanaland.domain.member.service;
+
+import com.jeju.nanaland.domain.member.entity.ConsentType;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.MemberConsent;
+import com.jeju.nanaland.domain.member.repository.MemberConsentRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberConsentService {
+
+  private final MemberConsentRepository memberConsentRepository;
+
+  public void createMemberConsents(Member member) {
+    List<MemberConsent> memberConsents = Arrays.stream(ConsentType.values())
+        .map(type -> MemberConsent.builder()
+            .member(member)
+            .consentType(type)
+            .consent(false)
+            .build())
+        .collect(Collectors.toList());
+    memberConsentRepository.saveAll(memberConsents);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberConsentService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberConsentService.java
@@ -1,14 +1,19 @@
 package com.jeju.nanaland.domain.member.service;
 
+import com.jeju.nanaland.domain.member.dto.MemberRequest.ConsentItem;
+import com.jeju.nanaland.domain.member.dto.MemberRequest.MemberConsentDTO;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.ConsentType;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.MemberConsent;
 import com.jeju.nanaland.domain.member.repository.MemberConsentRepository;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,5 +30,26 @@ public class MemberConsentService {
             .build())
         .collect(Collectors.toList());
     memberConsentRepository.saveAll(memberConsents);
+  }
+
+  @Transactional
+  public void updateConsent(MemberInfoDto memberInfoDto, MemberConsentDTO memberConsentDTO) {
+    for (ConsentItem consentItem : memberConsentDTO.getConsentItems()) {
+      Optional<MemberConsent> memberConsentOptional = memberConsentRepository.findByConsentTypeAndMember(
+          ConsentType.valueOf(consentItem.getConsentType()),
+          memberInfoDto.getMember());
+
+      if (memberConsentOptional.isPresent()) {
+        MemberConsent memberConsent = memberConsentOptional.get();
+        memberConsent.updateConsent(consentItem.getConsent());
+      } else {
+        MemberConsent memberConsent = MemberConsent.builder()
+            .member(memberInfoDto.getMember())
+            .consentType(ConsentType.valueOf(consentItem.getConsentType()))
+            .consent(consentItem.getConsent())
+            .build();
+        memberConsentRepository.save(memberConsent);
+      }
+    }
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -27,6 +27,7 @@ public class MemberLoginService {
   private final LanguageRepository languageRepository;
   private final ImageFileRepository imageFileRepository;
   private final JwtUtil jwtUtil;
+  private final MemberConsentService memberConsentService;
 
   @Transactional
   public JwtDto login(LoginDto loginDto) {
@@ -86,7 +87,11 @@ public class MemberLoginService {
         .provider(Provider.valueOf(loginDto.getProvider()))
         .providerId(loginDto.getProviderId())
         .build();
-    return memberRepository.save(member);
+    Member saveMember = memberRepository.save(member);
+    if (saveMember.getProvider() != Provider.GUEST) {
+      memberConsentService.createMemberConsents(saveMember);
+    }
+    return saveMember;
   }
 
   // 임시로 만든 랜덤 프로필 사진

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -18,6 +18,9 @@ public enum SuccessCode {
   UPDATE_MEMBER_TYPE_SUCCESS(OK, "사용자 타입 업데이트에 성공했습니다."),
   GET_RECOMMENDED_POSTS_SUCCESS(OK, "사용자 추천 게시물 조회에 성공했습니다."),
 
+  // member consent
+  CONSENT_UPDATE_SUCCESS(OK, "이용 약관 동의 여부 업데이트 성공"),
+
   // search
   SEARCH_SUCCESS(OK, "검색에 성공했습니다."),
   SEARCH_VOLUME_SUCCESS(OK, "검색량 UP 게시물 조회 성공"),


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 이용약관에 대한 동의 여부를 저장하는 테이블이 추가
- 이용약관 업데이트 API 추가

<br>

## 💬 To Reviewers
- [ ] ConsentType은 이용약관 및 개인정보처리방침(TERMS_OF_USE), 마켓팅 이용약관(MARKETING), 위치기반 서비스 동의(LOCATION_SERVICE)로 이루어져있습니다. 추후에 약관이 추가되어도 여기서 추가하면 될 것 같다고 생각합니다.

- [ ] 회원 가입이 진행될 때, 자동으로 모든 이용약관에 대한 값이 false로 지정되어 저장되는 상황입니다.

- [ ] 이용약관 업데이트 API를 통해 지정된 이용약관에 대한 값을 업데이트할 수 있습니다.

<br>

## ☑️ Related Issue
> 관련 이슈
close #120 