### PR TITLE
[Feat] 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -31,7 +31,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -150,11 +149,18 @@ public class MemberController {
     return BaseResponse.success(GET_RECOMMENDED_POSTS_SUCCESS, result);
   }
 
+  @Operation(
+      summary = "회원 탈퇴")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "필요한 입력이 없는 경우", content = @Content),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
+  })
   @PostMapping("/withdrawal")
-  public ResponseEntity withdrawal(
+  public BaseResponse<Null> withdrawal(
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid WithdrawalDto withdrawalType) {
     memberLoginService.withdrawal(memberInfoDto, withdrawalType);
-    return ResponseEntity.ok().build();
+    return BaseResponse.success(SuccessCode.WITHDRAWAL_SUCCESS);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_TYPE_
 import com.jeju.nanaland.domain.member.dto.MemberRequest;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.JoinDto;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
+import com.jeju.nanaland.domain.member.dto.MemberRequest.WithdrawalDto;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.RecommendPostDto;
 import com.jeju.nanaland.domain.member.service.MemberLoginService;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -146,5 +148,13 @@ public class MemberController {
     List<RecommendPostDto> result = memberTypeService.getRecommendPostsByType(
         memberInfoDto.getMember().getId());
     return BaseResponse.success(GET_RECOMMENDED_POSTS_SUCCESS, result);
+  }
+
+  @PostMapping("/withdrawal")
+  public ResponseEntity withdrawal(
+      @AuthMember MemberInfoDto memberInfoDto,
+      @RequestBody @Valid WithdrawalDto withdrawalType) {
+    memberLoginService.withdrawal(memberInfoDto, withdrawalType);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -5,6 +5,7 @@ import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.member.entity.ConsentType;
 import com.jeju.nanaland.domain.member.entity.MemberType;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.domain.member.entity.WithdrawalType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -121,4 +122,21 @@ public class MemberRequest {
             "GAMGYUL_LATTE", "GAMGYUL_SIKHYE", "GAMGYUL_ADE", "GAMGYUL_BUBBLE_TEA"})
     private String type;
   }
+
+  @Data
+  @Schema(description = "회원 탈퇴 요청 DTO")
+  public static class WithdrawalDto {
+
+    @Schema(description = "탈퇴 사유", example = "INSUFFICIENT_CONTENT",
+        allowableValues = {"INSUFFICIENT_CONTENT", "INCONVENIENT_SERVICE", "INCONVENIENT_COMMUNITY",
+            "RARE_VISITS"})
+    @NotBlank
+    @EnumValid(
+        enumClass = WithdrawalType.class,
+        message = "WithdrawalType이 유효하지 않습니다."
+    )
+    private String withdrawalType;
+
+  }
+
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,4 +35,11 @@ public class MemberWithdrawal {
   private WithdrawalType withdrawalType;
 
   private LocalDateTime withdrawalDate;
+
+  @Builder
+  public MemberWithdrawal(Member member, WithdrawalType withdrawalType) {
+    this.member = member;
+    this.withdrawalType = withdrawalType;
+    this.withdrawalDate = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
@@ -1,0 +1,37 @@
+package com.jeju.nanaland.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWithdrawal {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotNull
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private WithdrawalType withdrawalType;
+
+  private LocalDateTime withdrawalDate;
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/WithdrawalType.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/WithdrawalType.java
@@ -1,0 +1,5 @@
+package com.jeju.nanaland.domain.member.entity;
+
+public enum WithdrawalType {
+  INSUFFICIENT_CONTENT, INCONVENIENT_SERVICE, INCONVENIENT_COMMUNITY, RARE_VISITS
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberWithdrawalRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberWithdrawalRepository.java
@@ -1,0 +1,8 @@
+package com.jeju.nanaland.domain.member.repository;
+
+import com.jeju.nanaland.domain.member.entity.MemberWithdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberWithdrawalRepository extends JpaRepository<MemberWithdrawal, Long> {
+
+}

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -7,14 +7,19 @@ import static java.lang.String.format;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Language;
 import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.common.entity.Status;
 import com.jeju.nanaland.domain.common.repository.LanguageRepository;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.JoinDto;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.LoginDto;
+import com.jeju.nanaland.domain.member.dto.MemberRequest.WithdrawalDto;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.MemberWithdrawal;
 import com.jeju.nanaland.domain.member.entity.Provider;
+import com.jeju.nanaland.domain.member.entity.WithdrawalType;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
+import com.jeju.nanaland.domain.member.repository.MemberWithdrawalRepository;
 import com.jeju.nanaland.global.auth.jwt.dto.JwtResponseDto.JwtDto;
 import com.jeju.nanaland.global.exception.ConflictException;
 import com.jeju.nanaland.global.exception.ErrorCode;
@@ -33,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberLoginService {
 
   private final MemberRepository memberRepository;
+  private final MemberWithdrawalRepository memberWithdrawalRepository;
   private final LanguageRepository languageRepository;
   private final JwtUtil jwtUtil;
   private final MemberConsentService memberConsentService;
@@ -174,5 +180,17 @@ public class MemberLoginService {
     if (jwtUtil.findRefreshTokenById(memberId) != null) {
       jwtUtil.deleteRefreshToken(memberId);
     }
+  }
+
+  @Transactional
+  public void withdrawal(MemberInfoDto memberInfoDto, WithdrawalDto withdrawalType) {
+
+    memberInfoDto.getMember().updateStatus(Status.INACTIVE);
+
+    MemberWithdrawal memberWithdrawal = MemberWithdrawal.builder()
+        .member(memberInfoDto.getMember())
+        .withdrawalType(WithdrawalType.valueOf(withdrawalType.getWithdrawalType()))
+        .build();
+    memberWithdrawalRepository.save(memberWithdrawal);
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -27,6 +27,7 @@ public enum SuccessCode {
   LOGIN_SUCCESS(OK, "로그인에 성공했습니다."),
   REISSUE_TOKEN_SUCCESS(OK, "AccessToken, RefreshToken이 재발급되었습니다."),
   LOGOUT_SUCCESS(OK, "로그아웃 성공"),
+  WITHDRAWAL_SUCCESS(OK, "회원 탈퇴 성공"),
 
   // nana
   NANA_MAIN_SUCCESS(OK, "나나 메인 페이지 썸네일 조회 성공"),


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 회원 탈퇴 요청 시, 회원 탈퇴 사유와 함께 저장
- 회원의 status를 INACTIVE로 변환

<br>

## 💬 To Reviewers
- [ ] 회원 탈퇴 시에 비활성화 처리되어서 로그인이 X → 회원 가입을 하려고 할 텐데 회원 가입도 X
- [ ] 이유는 우리가 아직 회원의 정보를 DB에 가지고 있기 때문이에요.(특히 이메일)
- [ ] 그래서 이 문제를 해결하기 위해, 탈퇴 시에 완벽하게 DB에서 회원에 대한 개인정보를 삭제해야 합니다.(특히 이메일)
그렇다면, DB에서 회원 자체를 완전히 삭제할 것인지? 아니면 개인정보 부분만 비워놓는 식으로 할 것인지를 정해야 할 것 같아요
    
    완전히 회원을 삭제할 것이라면, 매핑 되어 있는 관계에 대한 처리가 걱정됩니다.
    아니면 완전히 회원은 삭제하고 임시로 만들어둔 다른 회원(”탈퇴한 회원입니다”)과 매핑시켜두거나,, 근데 복잡할까봐 걱정이네요
    
    개인정보만 비워놓는 식으로 하게 되면, 닉네임이랑 이메일은 UUID로 처리해서 겹쳐지지 않도록 해야하지 않을까 싶어요
    
- [ ] 탈퇴 시에 몇 개월동안은 개인정보를 보관하는 경우도 흔히 있는 것 같습니다. 이 경우에는 탈퇴일로부터 몇개월동안은 로그인 했을 때, 다시 회원을 활성화되도록 해야 합니다.

- [ ] 그렇다보니 이용약관에 대해서도 고민이 되는게, 이용 약관을 동의하게 되면 언제까지 유효한 건지..? 유효 기간이 끝나게 되면 어떻게 해야 하는 것인지가 또 궁금해졌습니다. 

<br>

## ☑️ Related Issue
> 관련 이슈
