### PR TITLE
[Feat] 비회원 이용약관 로직 수정 & 회원 탈퇴 조회 로직 수정 & 강제 회원 탈퇴 API

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_LANGUAGE_SUC
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_CONSENT_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_PROFILE_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_TYPE_SUCCESS;
+import static com.jeju.nanaland.global.exception.SuccessCode.WITHDRAWAL_SUCCESS;
 
 import com.jeju.nanaland.domain.member.dto.MemberRequest;
 import com.jeju.nanaland.domain.member.dto.MemberRequest.ConsentUpdateDto;
@@ -47,6 +48,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -170,7 +172,7 @@ public class MemberController {
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid WithdrawalDto withdrawalType) {
     memberLoginService.withdrawal(memberInfoDto, withdrawalType);
-    return BaseResponse.success(SuccessCode.WITHDRAWAL_SUCCESS);
+    return BaseResponse.success(WITHDRAWAL_SUCCESS);
   }
 
   @Operation(
@@ -235,5 +237,18 @@ public class MemberController {
   ) {
     memberConsentService.updateMemberConsent(memberInfoDto, consentUpdateDto);
     return BaseResponse.success(UPDATE_MEMBER_CONSENT_SUCCESS);
+  }
+
+  @Operation(
+      summary = "강제 회원 탈퇴 [테스트용]", description = "[회원 탈퇴]를 먼저 진행해야 합니다. 탈퇴일을 3개월 전으로 업데이트 및 개인 정보 삭제하여 즉시 회원 탈퇴 처리")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 데이터인 경우", content = @Content)
+  })
+  @PostMapping("/forceWithdrawal")
+  public BaseResponse<Null> forceWithdrawal(@RequestParam Long memberId) {
+    memberLoginService.forceWithdrawal(memberId);
+    return BaseResponse.success(WITHDRAWAL_SUCCESS);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -105,7 +105,7 @@ public class MemberRequest {
     )
     private String consentType;
 
-    @Schema(description = "동의 여부", defaultValue = "false")
+    @Schema(description = "동의 여부", defaultValue = "true")
     @NotNull
     private Boolean consent;
   }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
@@ -54,4 +54,8 @@ public class MemberWithdrawal {
   public void updateStatus(Status status) {
     this.status = status;
   }
+
+  public void updateWithdrawalDate() {
+    this.withdrawalDate = withdrawalDate.minusMonths(4);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/MemberWithdrawal.java
@@ -1,5 +1,7 @@
 package com.jeju.nanaland.domain.member.entity;
 
+import com.jeju.nanaland.domain.common.entity.Status;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,10 +17,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("status = 'ACTIVE'")
 public class MemberWithdrawal {
 
   @Id
@@ -36,10 +40,18 @@ public class MemberWithdrawal {
 
   private LocalDateTime withdrawalDate;
 
+  @Enumerated(value = EnumType.STRING)
+  @Column(name = "status")
+  private Status status = Status.ACTIVE;
+
   @Builder
   public MemberWithdrawal(Member member, WithdrawalType withdrawalType) {
     this.member = member;
     this.withdrawalType = withdrawalType;
     this.withdrawalDate = LocalDateTime.now();
+  }
+
+  public void updateStatus(Status status) {
+    this.status = status;
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberRepositoryImpl.java
@@ -52,7 +52,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
   public List<MemberConsent> findMemberConsentByMember(Member member) {
     return queryFactory
         .selectFrom(memberConsent)
-        .where(memberConsent.consentType.ne(ConsentType.TERMS_OF_USE))
+        .where(memberConsent.consentType.ne(ConsentType.TERMS_OF_USE)
+            .and(memberConsent.member.eq(member)))
         .fetch();
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/member/repository/MemberWithdrawalRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/MemberWithdrawalRepository.java
@@ -1,8 +1,11 @@
 package com.jeju.nanaland.domain.member.repository;
 
+import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.entity.MemberWithdrawal;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberWithdrawalRepository extends JpaRepository<MemberWithdrawal, Long> {
 
+  Optional<MemberWithdrawal> findByMember(Member member);
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.domain.member.service;
 
 import static com.jeju.nanaland.global.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.jeju.nanaland.global.exception.ErrorCode.MEMBER_WTIHDRAWAL_NOT_FOUND;
 import static com.jeju.nanaland.global.exception.ErrorCode.NICKNAME_DUPLICATE;
 
 import com.jeju.nanaland.domain.common.entity.ImageFile;
@@ -149,6 +150,10 @@ public class MemberLoginService {
   public void updateMemberActive(Member member) {
     if (member.getStatus().equals(Status.INACTIVE)) {
       member.updateStatus(Status.ACTIVE);
+
+      MemberWithdrawal memberWithdrawal = memberWithdrawalRepository.findByMember(member)
+          .orElseThrow(() -> new NotFoundException(MEMBER_WTIHDRAWAL_NOT_FOUND.getMessage()));
+      memberWithdrawal.updateStatus(Status.INACTIVE);
     }
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -218,4 +218,15 @@ public class MemberLoginService {
       members.forEach(Member::updatePersonalInfo);
     }
   }
+
+  @Transactional
+  public void forceWithdrawal(Long memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND.getMessage()));
+
+    MemberWithdrawal memberWithdrawal = memberWithdrawalRepository.findByMember(member)
+        .orElseThrow(() -> new NotFoundException(MEMBER_WTIHDRAWAL_NOT_FOUND.getMessage()));
+    memberWithdrawal.updateWithdrawalDate(); // 탈퇴일을 4개월 전으로 변경
+    deleteWithdrawalMemberInfo();
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -64,7 +64,9 @@ public class MemberLoginService {
     String nickname = validateNickname(joinDto);
     ImageFile profileImageFile = getProfileImageFile(multipartFile);
     Member member = createMember(joinDto, profileImageFile, nickname);
-    memberConsentService.createMemberConsents(member, joinDto.getConsentItems());
+    if (!member.getProvider().equals(Provider.GUEST)) {
+      memberConsentService.createMemberConsents(member, joinDto.getConsentItems());
+    }
     return getJwtDto(member);
   }
 

--- a/src/main/java/com/jeju/nanaland/global/config/SecurityConfig.java
+++ b/src/main/java/com/jeju/nanaland/global/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests(authHttpRequests -> authHttpRequests
             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/favicon.ico",
-                "/member/join", "/member/login", "/member/reissue", "/share/**")
+                "/member/join", "/member/login", "/member/reissue", "/share/**",
+                "member/forceWithdrawal")
             .permitAll()
             .requestMatchers("/favorite/**", "/member/type")
             .hasAnyRole("MEMBER", "ADMIN")

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
   NANA_NOT_FOUND(NOT_FOUND, "존재하지 않는 Nana 입니다."),
   NANA_TITLE_NOT_FOUND(NOT_FOUND, "존재하지 않는 Nana Title 입니다."),
   MEMBER_CONSENT_NOT_FOUND(NOT_FOUND, "존재하는 이용약관 동의 여부를 찾을 수 없습니다"),
+  MEMBER_WTIHDRAWAL_NOT_FOUND(NOT_FOUND, "존재하는 회원의 탈퇴 상태를 찾을 수 없습니다"),
+
   CONFLICT_DATA(CONFLICT, "이미 존재하는 데이터입니다."),
   MEMBER_DUPLICATE(CONFLICT, "이미 가입된 계정이 존재합니다."),
   NICKNAME_DUPLICATE(CONFLICT, "해당 닉네임은 다른 사용자가 사용 중입니다."),


### PR DESCRIPTION
## 📝 Description
> 작업 내용
-
-

<br>

## 💬 To Reviewers
- [ ] 이용약관을 저장하는 로직을 변동하면서, 비회원의 경우에도 이용약관이 저장되도록 하게 되어버려서 생겼던 오류 해결 (비회원은 이용약관 함수를 만들지 않도록 함)
- [ ] 회원 탈퇴 테이블에 status 추가, 이유는 탈퇴했다가 취소되는 경우를 나타내야했기 때문
- [ ] 프로필 조회 시, 불필요한 이용약관까지 조회되는 경우 오류 해결(member가 같은 것만 가져오는 조건을 빼먹음 바보)
- [ ] 테스트용 강제 회원 탈퇴 api 추가, memberId에 해당하는 탈퇴일을 4개월 전으로 변동시키며, 스케줄러를 강제로 실행시키도록 하여 탈퇴 처리 
-> admin만 가능한 api로 만들까도 하였으나, 프론트 개발자분들이 회원 탈퇴 api 후에 강제 회원 탈퇴 api를 실행해야 하다보니, 여기에 admin으로 로그인까지 해야하면 번거로워하실 것 같아서 그냥 permitall해두었습니다.
운영하기 전엔 꼭 admin으로 바꾸던지 api를 삭제해야 할 것 같네용

<br>

## ☑️ Related Issue
> 관련 이슈
close #206 