### PR TITLE
[Refactor] 추천 이미지 origin 이미지로 반환

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/repository/RecommendRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/repository/RecommendRepositoryImpl.java
@@ -37,7 +37,7 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
         .select(new QMemberResponse_RecommendPostDto(
             recommend.postId,
             recommend.category.content,
-            imageFile.thumbnailUrl,
+            imageFile.originUrl,
             natureTrans.title,
             recommendTrans.introduction
         ))
@@ -61,7 +61,7 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
         .select(new QMemberResponse_RecommendPostDto(
             recommend.postId,
             recommend.category.content,
-            imageFile.thumbnailUrl,
+            imageFile.originUrl,
             experienceTrans.title,
             recommendTrans.introduction
         ))
@@ -91,7 +91,7 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
         .select(new QMemberResponse_RecommendPostDto(
             recommend.postId,
             recommend.category.content,
-            imageFile.thumbnailUrl,
+            imageFile.originUrl,
             marketTrans.title,
             recommendTrans.introduction
         ))
@@ -120,7 +120,7 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
         .select(new QMemberResponse_RecommendPostDto(
             recommend.postId,
             recommend.category.content,
-            imageFile.thumbnailUrl,
+            imageFile.originUrl,
             festivalTrans.title,
             recommendTrans.introduction
         ))
@@ -149,7 +149,7 @@ public class RecommendRepositoryImpl implements RecommendRepositoryCustom {
         .select(new QMemberResponse_RecommendPostDto(
             recommend.postId,
             recommend.category.content,
-            imageFile.thumbnailUrl,
+            imageFile.originUrl,
             nanaTitle.heading,
             recommendTrans.introduction
         ))


### PR DESCRIPTION
## 📝 Description
- 타입 추천 결과창에서 추천 이미지 화질이 깨져서 origin 이미지로 반환

<br>

## 💬 To Reviewers
- 지금 반환 필드는 thumbnail 인데 이걸 origin으로 변경하면 프론트 분들도 변동사항이 생겨서 놔뒀습니다.
- 예전에 얘기한대로 MVP2에서는 origin이랑 thumbnail을 모두 반환하고 프론트에서 원하는 걸 가져다 쓰는 방식으로 하면 좋을 거 같아요

<br>

## ☑️ Related Issue
- close #244 
