### PR TITLE
[Feat] mvp2 market 썸네일 조회, 상세조회

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/dto/CompositeDto.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/dto/CompositeDto.java
@@ -11,8 +11,6 @@ import lombok.NoArgsConstructor;
 public class CompositeDto {
 
   private Long id;
-  private String originUrl;
-  private String thumbnailUrl;
   private String contact;
   private String locale;
   private String title;
@@ -20,14 +18,14 @@ public class CompositeDto {
   private String address;
   private String addressTag;
   private String time;
+  private ImageFileDto firstImage;
 
   @QueryProjection
   public CompositeDto(Long id, String originUrl, String thumbnailUrl, String contact,
       Locale locale, String title, String content, String address,
       String addressTag, String time) {
     this.id = id;
-    this.originUrl = originUrl;
-    this.thumbnailUrl = thumbnailUrl;
+    this.firstImage = new ImageFileDto(originUrl, thumbnailUrl);
     this.contact = contact;
     this.locale = locale.toString();
     this.title = title;

--- a/src/main/java/com/jeju/nanaland/domain/common/dto/CompositeDto.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/dto/CompositeDto.java
@@ -5,8 +5,10 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompositeDto {
 

--- a/src/main/java/com/jeju/nanaland/domain/common/dto/ImageFileDto.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/dto/ImageFileDto.java
@@ -1,0 +1,13 @@
+package com.jeju.nanaland.domain.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageFileDto {
+
+  private String originUrl;
+  private String thumbnailUrl;
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/dto/ImageFileDto.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/dto/ImageFileDto.java
@@ -1,11 +1,13 @@
 package com.jeju.nanaland.domain.common.dto;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ImageFileDto {
 
   private String originUrl;

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepository.java
@@ -3,6 +3,7 @@ package com.jeju.nanaland.domain.common.repository;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ImageFileRepository extends JpaRepository<ImageFile, Long> {
+public interface ImageFileRepository extends JpaRepository<ImageFile, Long>,
+    ImageFileRepositoryCustom {
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.jeju.nanaland.domain.common.repository;
+
+import com.jeju.nanaland.domain.common.dto.ImageFileDto;
+import java.util.List;
+
+public interface ImageFileRepositoryCustom {
+
+  List<ImageFileDto> findPostImageFiles(Long postId);
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ImageFileRepositoryImpl implements ImageFileRepositoryCustom {
             imageFile.originUrl,
             imageFile.thumbnailUrl))
         .from(imageFile)
-        .innerJoin(postImageFile.imageFile, imageFile)
+        .innerJoin(postImageFile).on(postImageFile.imageFile.eq(imageFile))
         .where(postImageFile.post.id.eq(postId))
         .orderBy(imageFile.id.asc())
         .fetch();

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
@@ -23,6 +23,7 @@ public class ImageFileRepositoryImpl implements ImageFileRepositoryCustom {
         .from(imageFile)
         .innerJoin(postImageFile.imageFile, imageFile)
         .where(postImageFile.post.id.eq(postId))
+        .orderBy(imageFile.id.asc())
         .fetch();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/ImageFileRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.jeju.nanaland.domain.common.repository;
+
+import static com.jeju.nanaland.domain.common.entity.QImageFile.imageFile;
+import static com.jeju.nanaland.domain.common.entity.QPostImageFile.postImageFile;
+
+import com.jeju.nanaland.domain.common.dto.ImageFileDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ImageFileRepositoryImpl implements ImageFileRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<ImageFileDto> findPostImageFiles(Long postId) {
+    return queryFactory
+        .select(Projections.constructor(ImageFileDto.class,
+            imageFile.originUrl,
+            imageFile.thumbnailUrl))
+        .from(imageFile)
+        .innerJoin(postImageFile.imageFile, imageFile)
+        .where(postImageFile.post.id.eq(postId))
+        .fetch();
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
@@ -257,7 +257,8 @@ public class FavoriteService {
     }
   }
 
-  public List<Long> getMemberFavoritePostIds(Member member, CategoryContent categoryContent) {
+  public List<Long> getFavoritePostIdsWithMemberAndCategory(Member member,
+      CategoryContent categoryContent) {
 
     Category category = getCategoryFromCategoryContent(categoryContent);
     List<Favorite> favorites = favoriteRepository.findAllByMemberAndCategory(member, category);

--- a/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
@@ -112,9 +112,9 @@ public class FestivalService {
     boolean isPostInFavorite = favoriteService.isPostInFavorite(memberInfoDto.getMember(), FESTIVAL,
         id);
 
+    // TODO: 이미지 추가 필요
     return FestivalDetailDto.builder()
         .id(compositeDtoById.getId())
-        .originUrl(compositeDtoById.getOriginUrl())
         .addressTag(compositeDtoById.getAddressTag())
         .title(compositeDtoById.getTitle())
         .content(compositeDtoById.getContent())
@@ -164,11 +164,11 @@ public class FestivalService {
       // LocalDate 타입의 startDate, endDate를 24. 04. 01 ~ 24. 05. 13형태로 formatting
       String period = formatLocalDateToStringWithoutDayOfWeek(memberInfoDto, dto.getStartDate(),
           dto.getEndDate());
+      // TODO: 이미지 추가 필요
       thumbnails.add(
           FestivalThumbnail.builder()
               .id(dto.getId())
               .title(dto.getTitle())
-              .thumbnailUrl(dto.getThumbnailUrl())
               .period(period)
               .addressTag(dto.getAddressTag())
               .isFavorite(favoriteIds.contains(dto.getId()))

--- a/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/service/FestivalService.java
@@ -226,7 +226,8 @@ public class FestivalService {
   }
 
   private List<Long> getMemberFavoriteFestivalIds(MemberInfoDto memberInfoDto) {
-    return favoriteService.getMemberFavoritePostIds(memberInfoDto.getMember(), FESTIVAL);
+    return favoriteService.getFavoritePostIdsWithMemberAndCategory(memberInfoDto.getMember(),
+        FESTIVAL);
   }
 
   private DayOfWeek getIntDayOfWeek(LocalDate date) {

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketCompositeDto.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketCompositeDto.java
@@ -4,13 +4,17 @@ import com.jeju.nanaland.domain.common.dto.CompositeDto;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
+@SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MarketCompositeDto extends CompositeDto {
 
   private String homepage;

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
@@ -1,6 +1,6 @@
 package com.jeju.nanaland.domain.market.dto;
 
-import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.dto.ImageFileDto;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -73,7 +73,7 @@ public class MarketResponse {
 
     @NotBlank
     @Schema(description = "전통시장 게시물 썸네일 사진")
-    private ImageFile image;
+    private ImageFileDto image;
 
     @Schema(description = "전통시장 게시물 제목")
     private String title;
@@ -90,7 +90,7 @@ public class MarketResponse {
     public MarketThumbnail(Long id, String originUrl, String thumbnailUrl, String title,
         String addressTag) {
       this.id = id;
-      this.image = new ImageFile(originUrl, thumbnailUrl);
+      this.image = new ImageFileDto(originUrl, thumbnailUrl);
       this.title = title;
       this.addressTag = addressTag;
     }

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
@@ -58,10 +58,7 @@ public class MarketResponse {
     @Schema(description = "좋아요 여부")
     private boolean isFavorite;
 
-    @Schema(description = "게시물 썸네일 이미지")
-    private ImageFileDto firstImage;
-
-    @Schema(description = "추가 이미지")
+    @Schema(description = "이미지 리스트")
     private List<ImageFileDto> images;
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
@@ -34,9 +34,6 @@ public class MarketResponse {
     @Schema(description = "제목")
     private String title;
 
-    @Schema(description = "원본 이미지 url")
-    private String originUrl;
-
     @Schema(description = "본문")
     private String content;
 
@@ -60,6 +57,12 @@ public class MarketResponse {
 
     @Schema(description = "좋아요 여부")
     private boolean isFavorite;
+
+    @Schema(description = "게시물 썸네일 이미지")
+    private ImageFileDto firstImage;
+
+    @Schema(description = "추가 이미지")
+    private List<ImageFileDto> images;
   }
 
   @Data
@@ -72,7 +75,7 @@ public class MarketResponse {
     private Long id;
 
     @NotBlank
-    @Schema(description = "전통시장 게시물 썸네일 사진")
+    @Schema(description = "게시물 썸네일 이미지")
     private ImageFileDto firstImage;
 
     @Schema(description = "전통시장 게시물 제목")

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
@@ -73,7 +73,7 @@ public class MarketResponse {
 
     @NotBlank
     @Schema(description = "전통시장 게시물 썸네일 사진")
-    private ImageFileDto image;
+    private ImageFileDto firstImage;
 
     @Schema(description = "전통시장 게시물 제목")
     private String title;
@@ -90,7 +90,7 @@ public class MarketResponse {
     public MarketThumbnail(Long id, String originUrl, String thumbnailUrl, String title,
         String addressTag) {
       this.id = id;
-      this.image = new ImageFileDto(originUrl, thumbnailUrl);
+      this.firstImage = new ImageFileDto(originUrl, thumbnailUrl);
       this.title = title;
       this.addressTag = addressTag;
     }

--- a/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/dto/MarketResponse.java
@@ -1,8 +1,11 @@
 package com.jeju.nanaland.domain.market.dto;
 
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -61,18 +64,19 @@ public class MarketResponse {
 
   @Data
   @Builder
+  @AllArgsConstructor
   @Schema(description = "전통시장 게시물 정보")
   public static class MarketThumbnail {
 
     @Schema(description = "전통시장 게시물 id")
     private Long id;
 
+    @NotBlank
+    @Schema(description = "전통시장 게시물 썸네일 사진")
+    private ImageFile image;
+
     @Schema(description = "전통시장 게시물 제목")
     private String title;
-
-    @NotBlank
-    @Schema(description = "전통시장 게시물 썸네일 url")
-    private String thumbnailUrl;
 
     @NotBlank
     @Schema(description = "위치 정보 태그")
@@ -81,5 +85,14 @@ public class MarketResponse {
     @NotBlank
     @Schema(description = "좋아요 여부")
     private boolean isFavorite;
+
+    @QueryProjection
+    public MarketThumbnail(Long id, String originUrl, String thumbnailUrl, String title,
+        String addressTag) {
+      this.id = id;
+      this.image = new ImageFile(originUrl, thumbnailUrl);
+      this.title = title;
+      this.addressTag = addressTag;
+    }
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.market.repository;
 
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
+import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnail;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +11,7 @@ public interface MarketRepositoryCustom {
 
   MarketCompositeDto findCompositeDtoById(Long id, Locale locale);
 
-  Page<MarketCompositeDto> findMarketThumbnails(Locale locale, List<String> addressFilterList,
+  Page<MarketThumbnail> findMarketThumbnails(Locale locale, List<String> addressFilterList,
       Pageable pageable);
 
   Page<MarketCompositeDto> searchCompositeDtoByKeyword(String keyword, Locale locale,

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
@@ -68,7 +68,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         .innerJoin(market.marketTrans, marketTrans)
         .where(marketTrans.language.locale.eq(locale)
             .and(addressTagCondition(addressFilterList)))
-        .orderBy(market.createdAt.desc())
+        .orderBy(market.priority.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
@@ -9,7 +9,9 @@ import static com.jeju.nanaland.domain.market.entity.QMarketTrans.marketTrans;
 import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
+import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnail;
 import com.jeju.nanaland.domain.market.dto.QMarketCompositeDto;
+import com.jeju.nanaland.domain.market.dto.QMarketResponse_MarketThumbnail;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -51,28 +53,19 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
   }
 
   @Override
-  public Page<MarketCompositeDto> findMarketThumbnails(Locale locale,
-      List<String> addressFilterList,
+  public Page<MarketThumbnail> findMarketThumbnails(Locale locale, List<String> addressFilterList,
       Pageable pageable) {
-    List<MarketCompositeDto> resultDto = queryFactory
-        .select(new QMarketCompositeDto(
+    List<MarketThumbnail> resultDto = queryFactory
+        .select(new QMarketResponse_MarketThumbnail(
             market.id,
             imageFile.originUrl,
             imageFile.thumbnailUrl,
-            market.contact,
-            market.homepage,
-            language.locale,
             marketTrans.title,
-            marketTrans.content,
-            marketTrans.address,
-            marketTrans.addressTag,
-            marketTrans.time,
-            marketTrans.intro,
-            marketTrans.amenity
+            marketTrans.addressTag
         ))
         .from(market)
-        .leftJoin(market.firstImageFile, imageFile)
-        .leftJoin(market.marketTrans, marketTrans)
+        .innerJoin(market.firstImageFile, imageFile)
+        .innerJoin(market.marketTrans, marketTrans)
         .where(marketTrans.language.locale.eq(locale)
             .and(addressTagCondition(addressFilterList)))
         .orderBy(market.createdAt.desc())
@@ -83,7 +76,7 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
     JPAQuery<Long> countQuery = queryFactory
         .select(market.count())
         .from(market)
-        .leftJoin(market.marketTrans, marketTrans)
+        .innerJoin(market.marketTrans, marketTrans)
         .where(marketTrans.language.locale.eq(locale)
             .and(addressTagCondition(addressFilterList)));
 

--- a/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
@@ -15,6 +15,7 @@ import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.search.service.SearchService;
 import com.jeju.nanaland.global.exception.ErrorCode;
 import com.jeju.nanaland.global.exception.NotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,13 +76,14 @@ public class MarketService {
     // TODO: category 없애는 리팩토링 필요
     // 좋아요 여부 확인
     boolean isFavorite = favoriteService.isPostInFavorite(memberInfoDto.getMember(), MARKET, id);
-    // 추가 이미지 조회
-    List<ImageFileDto> additionalImages = imageFileRepository.findPostImageFiles(id);
+    // 이미지 리스트
+    List<ImageFileDto> images = new ArrayList<>();
+    images.add(marketCompositeDto.getFirstImage());
+    images.addAll(imageFileRepository.findPostImageFiles(id));
 
     return MarketResponse.MarketDetailDto.builder()
         .id(marketCompositeDto.getId())
-        .firstImage(marketCompositeDto.getFirstImage())
-        .images(additionalImages)
+        .images(images)
         .title(marketCompositeDto.getTitle())
         .content(marketCompositeDto.getContent())
         .address(marketCompositeDto.getAddress())

--- a/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/service/MarketService.java
@@ -39,7 +39,7 @@ public class MarketService {
     Page<MarketThumbnail> marketThumbnailPage = marketRepository.findMarketThumbnails(locale,
         addressFilterList, pageable);
 
-    //
+    // TODO: postId가 중복되지 않기 때문에 카테고리 정보와 함께 가져올 필요가 없음. 나중에 리팩토링 필요
     List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(
         memberInfoDto.getMember(), MARKET);
 

--- a/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
@@ -40,12 +40,12 @@ public class NatureService {
     List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(
         memberInfoDto.getMember(), NATURE);
 
+    // TODO: 이미지 추가 필요
     List<NatureThumbnail> data = natureCompositeDtoPage.getContent()
         .stream().map(natureCompositeDto ->
             NatureThumbnail.builder()
                 .id(natureCompositeDto.getId())
                 .title(natureCompositeDto.getTitle())
-                .thumbnailUrl(natureCompositeDto.getThumbnailUrl())
                 .addressTag(natureCompositeDto.getAddressTag())
                 .isFavorite(favoriteIds.contains(natureCompositeDto.getId()))
                 .build()).toList();
@@ -71,9 +71,9 @@ public class NatureService {
     boolean isPostInFavorite = favoriteService.isPostInFavorite(memberInfoDto.getMember(), NATURE,
         id);
 
+    // TODO: 이미지 추가 필요
     return NatureDetailDto.builder()
         .id(natureCompositeDto.getId())
-        .originUrl(natureCompositeDto.getOriginUrl())
         .addressTag(natureCompositeDto.getAddressTag())
         .title(natureCompositeDto.getTitle())
         .content(natureCompositeDto.getContent())

--- a/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/service/NatureService.java
@@ -37,7 +37,7 @@ public class NatureService {
     Page<NatureCompositeDto> natureCompositeDtoPage = natureRepository.findNatureThumbnails(
         memberInfoDto.getLanguage().getLocale(), addressFilterList, keyword, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(
         memberInfoDto.getMember(), NATURE);
 
     List<NatureThumbnail> data = natureCompositeDtoPage.getContent()

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -94,11 +94,11 @@ public class SearchService {
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (NatureCompositeDto dto : resultPage) {
+      // TODO: 이미지 추가 필요
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
               .category(NATURE.name())
-              .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
               .build());
@@ -127,11 +127,11 @@ public class SearchService {
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (FestivalCompositeDto dto : resultPage) {
+      // TODO: 이미지 추가 필요
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
               .category(FESTIVAL.name())
-              .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
               .build());
@@ -160,11 +160,11 @@ public class SearchService {
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (ExperienceCompositeDto dto : resultPage) {
+      // TODO: 이미지 추가 필요
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
               .category(EXPERIENCE.name())
-              .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
               .build());
@@ -193,11 +193,11 @@ public class SearchService {
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (MarketCompositeDto dto : resultPage) {
+      // TODO: 이미지 추가 필요
       thumbnails.add(
           ThumbnailDto.builder()
               .id(dto.getId())
               .category(MARKET.name())
-              .thumbnailUrl(dto.getThumbnailUrl())
               .title(dto.getTitle())
               .isFavorite(favoriteIds.contains(dto.getId()))
               .build());
@@ -378,10 +378,10 @@ public class SearchService {
     if (compositeDto == null) {
       throw new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION.getMessage());
     }
+    // TODO: 이미지 추가 필요
     return SearchVolumeDto.builder()
         .id(compositeDto.getId())
         .title(compositeDto.getTitle())
-        .thumbnailUrl(compositeDto.getThumbnailUrl())
         .category(categoryContent.name())
         .isFavorite(
             favoriteService.isPostInFavorite(memberInfoDto.getMember(), categoryContent,

--- a/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
+++ b/src/main/java/com/jeju/nanaland/domain/search/service/SearchService.java
@@ -89,7 +89,8 @@ public class SearchService {
     Page<NatureCompositeDto> resultPage = natureRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, NATURE);
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(member,
+        NATURE);
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (NatureCompositeDto dto : resultPage) {
@@ -121,7 +122,8 @@ public class SearchService {
     Page<FestivalCompositeDto> resultPage = festivalRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, FESTIVAL);
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(member,
+        FESTIVAL);
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (FestivalCompositeDto dto : resultPage) {
@@ -153,7 +155,8 @@ public class SearchService {
     Page<ExperienceCompositeDto> resultPage = experienceRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, EXPERIENCE);
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(member,
+        EXPERIENCE);
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (ExperienceCompositeDto dto : resultPage) {
@@ -185,7 +188,8 @@ public class SearchService {
     Page<MarketCompositeDto> resultPage = marketRepository.searchCompositeDtoByKeyword(
         keyword, locale, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, MARKET);
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(member,
+        MARKET);
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (MarketCompositeDto dto : resultPage) {
@@ -217,7 +221,7 @@ public class SearchService {
     Page<NanaThumbnail> resultPage = nanaRepository.searchNanaThumbnailDtoByKeyword(
         keyword, locale, pageable);
 
-    List<Long> favoriteIds = favoriteService.getMemberFavoritePostIds(member, NANA);
+    List<Long> favoriteIds = favoriteService.getFavoritePostIdsWithMemberAndCategory(member, NANA);
 
     List<SearchResponse.ThumbnailDto> thumbnails = new ArrayList<>();
     for (NanaThumbnail thumbnail : resultPage) {

--- a/src/test/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryTest.java
@@ -1,12 +1,24 @@
 package com.jeju.nanaland.domain.market.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.jeju.nanaland.config.TestConfig;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
+import com.jeju.nanaland.domain.common.entity.Language;
 import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnail;
+import com.jeju.nanaland.domain.market.entity.Market;
+import com.jeju.nanaland.domain.market.entity.MarketTrans;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -17,10 +29,76 @@ class MarketRepositoryTest {
   @Autowired
   MarketRepository marketRepository;
 
+  @Autowired
+  TestEntityManager em;
+
   @Test
   @DisplayName("전통시장 검색")
   void searchMarketTest() {
     Pageable pageable = PageRequest.of(0, 12);
     marketRepository.searchCompositeDtoByKeyword("쇼핑", Locale.KOREAN, pageable);
+  }
+
+  @Test
+  @DisplayName("전통시장 썸네일 조회")
+  void findMarketThumbnailsTest() {
+    // given
+    Language korean = initKoreanLanguage();
+    List<Market> marketList = getMarketList(korean);
+    for (Market market : marketList) {
+      System.out.println(market.getCreatedAt());
+    }
+
+    Locale locale = Locale.KOREAN;
+    List<String> addressFilter = Arrays.asList("제주시");
+    Pageable pageable = PageRequest.of(0, 2);
+
+    // when
+    Page<MarketThumbnail> marketThumbnails = marketRepository.findMarketThumbnails(locale,
+        addressFilter, pageable);
+    List<MarketThumbnail> thumbnails = marketThumbnails.getContent();
+
+    // then
+    assertThat(thumbnails).hasSize(2);
+    assertThat(thumbnails.get(0)).extracting("title").isEqualTo("market title 10");
+    assertThat(thumbnails.get(1)).extracting("title").isEqualTo("market title 9");
+  }
+
+  // KOREAN 언어 정보 초기 설정
+  Language initKoreanLanguage() {
+    Language korean = Language.builder()
+        .locale(Locale.KOREAN)
+        .dateFormat("yyyy-mm-dd")
+        .build();
+    em.persist(korean);
+    return korean;
+  }
+
+  // 언어: KOREAN, 전통시장 데이터 10개 생성
+  List<Market> getMarketList(Language language) {
+    List<Market> marketList = new ArrayList<>();
+    for (int i = 1; i < 11; i++) {
+      ImageFile imageFile = ImageFile.builder()
+          .originUrl("originUrl" + i)
+          .thumbnailUrl("thumbnailUrl" + i)
+          .build();
+      em.persist(imageFile);
+      Market market = Market.builder()
+          .firstImageFile(imageFile)
+          .priority(0L)
+          .build();
+      em.persistAndFlush(market);
+      MarketTrans marketTrans1 = MarketTrans.builder()
+          .market(market)
+          .title("market title " + i)
+          .language(language)
+          .addressTag("제주시")
+          .build();
+      em.persist(marketTrans1);
+
+      marketList.add(market);
+    }
+
+    return marketList;
   }
 }

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -1,13 +1,33 @@
 package com.jeju.nanaland.domain.market.service;
 
-import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import com.jeju.nanaland.domain.common.data.CategoryContent;
+import com.jeju.nanaland.domain.common.entity.Language;
+import com.jeju.nanaland.domain.common.entity.Locale;
+import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnail;
+import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnailDto;
 import com.jeju.nanaland.domain.market.repository.MarketRepository;
+import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
+import com.jeju.nanaland.domain.member.entity.Member;
+import com.jeju.nanaland.domain.member.entity.MemberTravelType;
+import com.jeju.nanaland.domain.member.entity.enums.TravelType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class MarketServiceTest {
@@ -18,12 +38,60 @@ class MarketServiceTest {
   @Mock
   MarketRepository marketRepository;
   @Mock
-  FavoriteRepository favoriteRepository;
+  FavoriteService favoriteService;
 
   @Test
   @DisplayName("전통시장 썸네일 페이징")
   void marketThumbnailPagingTest() {
+    // given
+    Locale locale = Locale.KOREAN;
+    List<String> filterList = Arrays.asList("제주시");
+    MemberInfoDto memberInfoDto = createMemberInfoDto(locale, TravelType.NONE);
+    Pageable pageable = PageRequest.of(0, 2);
 
+    doReturn(getMarketThumbnailList()).when(marketRepository)
+        .findMarketThumbnails(locale, filterList, pageable);
+    doReturn(new ArrayList<>()).when(favoriteService)
+        .getFavoritePostIdsWithMemberAndCategory(any(Member.class), any(CategoryContent.class));
+
+    // when
+    MarketThumbnailDto result = marketService.getMarketList(memberInfoDto, filterList, 0, 2);
+
+    // then
+    assertThat(result.getTotalElements()).isEqualTo(10);
+    assertThat(result.getData().size()).isEqualTo(2);
+    assertThat(result.getData().get(0).getTitle()).isEqualTo("market title 1");
   }
 
+  // totalElement: 10, MarketThumbnail 데이터가 2개인 Page 생성
+  Page<MarketThumbnail> getMarketThumbnailList() {
+    List<MarketThumbnail> marketThumbnailList = new ArrayList<>();
+    for (int i = 1; i < 3; i++) {
+      marketThumbnailList.add(
+          MarketThumbnail.builder()
+              .title("market title " + i)
+              .addressTag("제주시")
+              .build());
+    }
+
+    return new PageImpl<>(marketThumbnailList, PageRequest.of(0, 2), 10);
+  }
+
+  MemberInfoDto createMemberInfoDto(Locale locale, TravelType travelType) {
+    Language language = Language.builder()
+        .locale(locale)
+        .build();
+    MemberTravelType memberTravelType = MemberTravelType.builder()
+        .travelType(travelType)
+        .build();
+    Member member = Member.builder()
+        .language(language)
+        .memberTravelType(memberTravelType)
+        .build();
+
+    return MemberInfoDto.builder()
+        .member(member)
+        .language(language)
+        .build();
+  }
 }

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -94,8 +94,7 @@ class MarketServiceTest {
     MarketDetailDto result = marketService.getMarketDetail(memberInfoDto, 1L, false);
 
     // then
-    assertThat(result.getFirstImage().getOriginUrl()).isEqualTo("first origin url");
-    assertThat(result.getImages().size()).isEqualTo(2);
+    assertThat(result.getImages().size()).isEqualTo(3);
   }
 
   // totalElement: 10, MarketThumbnail 데이터가 2개인 Page 생성

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -7,16 +7,14 @@ import static org.mockito.Mockito.doReturn;
 
 import com.jeju.nanaland.domain.common.data.CategoryContent;
 import com.jeju.nanaland.domain.common.dto.ImageFileDto;
-import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Language;
 import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.favorite.service.FavoriteService;
+import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
 import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketDetailDto;
 import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnail;
 import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketThumbnailDto;
-import com.jeju.nanaland.domain.market.entity.Market;
-import com.jeju.nanaland.domain.market.entity.MarketTrans;
 import com.jeju.nanaland.domain.market.repository.MarketRepository;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
@@ -78,10 +76,8 @@ class MarketServiceTest {
     // given
     Locale locale = Locale.KOREAN;
     MemberInfoDto memberInfoDto = createMemberInfoDto(locale, TravelType.NONE);
-    MarketDetailDto marketDetailDto = MarketDetailDto.builder()
-        .firstImage(
-            new ImageFileDto("first origin url", "first thumbnail url"))
-        .images(new ArrayList<>()) // 빈 리스트
+    MarketCompositeDto marketDetailDto = MarketCompositeDto.builder()
+        .firstImage(new ImageFileDto("first origin url", "first thumbnail url"))
         .build();
     List<ImageFileDto> additionalImages = Arrays.asList(
         new ImageFileDto("origin url 1", "thumbnail url 1"),
@@ -100,31 +96,6 @@ class MarketServiceTest {
     // then
     assertThat(result.getFirstImage().getOriginUrl()).isEqualTo("first origin url");
     assertThat(result.getImages().size()).isEqualTo(2);
-  }
-
-  private Market initMarketDetail() {
-    ImageFile firstImage = ImageFile.builder()
-        .originUrl("first origin url")
-        .thumbnailUrl("first thumbnail url")
-        .build();
-    ImageFile additionalImage1 = ImageFile.builder()
-        .originUrl("origin url")
-        .thumbnailUrl("thumbnail url")
-        .build();
-    ImageFile additionalImage2 = ImageFile.builder()
-        .originUrl("origin url")
-        .thumbnailUrl("thumbnail url")
-        .build();
-
-    Market market = Market.builder()
-        .firstImageFile(firstImage)
-        .priority(0L)
-        .build();
-    MarketTrans marketTrans = MarketTrans.builder()
-        .market(market)
-        .build();
-
-    return market;
   }
 
   // totalElement: 10, MarketThumbnail 데이터가 2개인 Page 생성

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -1,98 +1,29 @@
 package com.jeju.nanaland.domain.market.service;
 
-import com.jeju.nanaland.domain.common.data.CategoryContent;
-import com.jeju.nanaland.domain.common.entity.Category;
-import com.jeju.nanaland.domain.common.entity.ImageFile;
-import com.jeju.nanaland.domain.common.entity.Language;
-import com.jeju.nanaland.domain.common.entity.Locale;
 import com.jeju.nanaland.domain.favorite.repository.FavoriteRepository;
-import com.jeju.nanaland.domain.market.entity.Market;
-import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
-import com.jeju.nanaland.domain.member.entity.Member;
-import com.jeju.nanaland.domain.member.entity.enums.Provider;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import com.jeju.nanaland.domain.market.repository.MarketRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class MarketServiceTest {
 
-  @Autowired
-  EntityManager em;
-  @Autowired
+  @InjectMocks
   MarketService marketService;
-  @Autowired
+
+  @Mock
+  MarketRepository marketRepository;
+  @Mock
   FavoriteRepository favoriteRepository;
 
-  Language language;
-  Member member1, member2;
-  MemberInfoDto memberInfoDto1, memberInfoDto2;
+  @Test
+  @DisplayName("전통시장 썸네일 페이징")
+  void marketThumbnailPagingTest() {
 
-  Market market;
-  Category category;
-
-  @BeforeEach
-  void init() {
-    ImageFile imageFile1 = ImageFile.builder()
-        .originUrl("origin")
-        .thumbnailUrl("thumbnail")
-        .build();
-    em.persist(imageFile1);
-
-    ImageFile imageFile2 = ImageFile.builder()
-        .originUrl("origin")
-        .thumbnailUrl("thumbnail")
-        .build();
-    em.persist(imageFile2);
-
-    language = Language.builder()
-        .locale(Locale.KOREAN)
-        .dateFormat("yy-mm-dd")
-        .build();
-    em.persist(language);
-
-    member1 = Member.builder()
-        .email("test@naver.com")
-        .provider(Provider.KAKAO)
-        .providerId("123456789")
-        .nickname("nickname1")
-        .language(language)
-        .profileImageFile(imageFile1)
-        .build();
-    em.persist(member1);
-
-    member2 = Member.builder()
-        .email("test2@naver.com")
-        .provider(Provider.KAKAO)
-        .providerId("1234567890")
-        .nickname("nickname2")
-        .language(language)
-        .profileImageFile(imageFile2)
-        .build();
-    em.persist(member2);
-
-    memberInfoDto1 = MemberInfoDto.builder()
-        .language(language)
-        .member(member1)
-        .build();
-
-    memberInfoDto2 = MemberInfoDto.builder()
-        .language(language)
-        .member(member2)
-        .build();
-
-    market = Market.builder()
-        .firstImageFile(imageFile1)
-        .priority(0L)
-        .build();
-    em.persist(market);
-
-    category = Category.builder()
-        .content(CategoryContent.MARKET)
-        .build();
-    em.persist(category);
   }
+
 }


### PR DESCRIPTION
## 📝 Description
- 전통시장 썸네일 조회
![image](https://github.com/Travel-in-nanaland/Back-end/assets/98393795/3a329c19-f84d-46a9-a7bd-fe9ce7f51462)

- 전통시장 상세조회
![image](https://github.com/Travel-in-nanaland/Back-end/assets/98393795/3822da18-25a8-4ae9-8f2b-b090a98ee932)


<br>

## 💬 To Reviewers
- 썸네일 정보 요청 쿼리를 기존의 compositeDto에서 MarketThumbnailDto로 변경
- compositeDto가 상속관계로 묶여있어서 다른 카테고리들도 수정이 필요했는데 우선은 market만 처리해두고 나머지는 TODO를 통해 표시해뒀습니다.
- [24.06.22] 상세조회 response에 firstImage를 Images에 포함되도록 수정

<br>

## ☑️ Related Issue
- close #254 
