### PR TITLE
Feat/#306 review search auto complete

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/data/Category.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/data/Category.java
@@ -1,11 +1,38 @@
 package com.jeju.nanaland.domain.common.data;
 
+import lombok.Getter;
+
+@Getter
 public enum Category {
-  NANA,
-  NANA_CONTENT,
-  EXPERIENCE,
-  FESTIVAL,
-  NATURE,
-  MARKET,
-  RESTAURANT
+  NANA("나나's pick", "enNana", "viNana", "msNana", "zaNana"),
+  NANA_CONTENT("나나 상세", "enNanaContent", "vienNanaContent", "msenNanaContent", "zhenNanaContent"),
+  EXPERIENCE("이색 체험", "enExperience", "viExperience", "msExperience", "zhExperience"),
+  FESTIVAL("축제", "enFestival", "viFestival", "msFestival", "zhFestival"),
+  NATURE("7대 자연", "enNature", "viNature", "msNature", "zhNature"),
+  MARKET("전통시장", "enMarket", "viMarket", "msMarket", "zhMarket"),
+  RESTAURANT("제주 맛집", "enRestaurant", "viRestaurant", "msRestaurant", "zhRestaurant");
+
+  private final String kr;
+  private final String en; //영어
+  private final String vi; //베트남어
+  private final String ms; //말레이시아어
+  private final String zh; //중국어
+
+  Category(String kr, String en, String vi, String ms, String zh) {
+    this.kr = kr;
+    this.en = en;
+    this.vi = vi;
+    this.ms = ms;
+    this.zh = zh;
+  }
+
+  public String getValueByLocale(Language locale) {
+    return switch (locale) {
+      case KOREAN -> this.getKr();
+      case ENGLISH -> this.getEn();
+      case CHINESE -> this.getZh();
+      case MALAYSIA -> this.getMs();
+      case VIETNAMESE -> this.getVi();
+    };
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.jeju.nanaland.domain.experience.dto.ExperienceCompositeDto;
 import com.jeju.nanaland.domain.experience.dto.ExperienceResponse.ExperienceThumbnail;
 import com.jeju.nanaland.domain.experience.entity.enums.ExperienceType;
 import com.jeju.nanaland.domain.experience.entity.enums.ExperienceTypeKeyword;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.domain.Page;
@@ -22,4 +23,6 @@ public interface ExperienceRepositoryCustom {
       List<String> addressFilterList, Pageable pageable);
 
   Set<ExperienceTypeKeyword> getExperienceTypeKeywordSet(Long postId);
+
+  List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language);
 }

--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
@@ -173,11 +173,11 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
     return queryFactory
         .select(
             new QReviewResponse_SearchPostForReviewDto(experience.id,
-                Expressions.stringTemplate("'{0}'", Category.EXPERIENCE),
+                Expressions.constant(Category.EXPERIENCE.name()),
                 experienceTrans.title, experience.firstImageFile, experienceTrans.address))
         .from(experience)
-        .leftJoin(experienceTrans)
-        .on(experienceTrans.language.eq(language))
+        .innerJoin(experience.experienceTrans, experienceTrans)
+        .where(experienceTrans.language.eq(language))
         .fetch();
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
@@ -14,8 +14,11 @@ import com.jeju.nanaland.domain.experience.dto.QExperienceCompositeDto;
 import com.jeju.nanaland.domain.experience.dto.QExperienceResponse_ExperienceThumbnail;
 import com.jeju.nanaland.domain.experience.entity.enums.ExperienceType;
 import com.jeju.nanaland.domain.experience.entity.enums.ExperienceTypeKeyword;
+import com.jeju.nanaland.domain.review.dto.QReviewResponse_SearchPostForReviewDto;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
@@ -163,6 +166,19 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
             .as(GroupBy.set(experienceKeyword.experienceTypeKeyword)));
 
     return map.getOrDefault(postId, Collections.emptySet());
+  }
+
+  @Override
+  public List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language) {
+    return queryFactory
+        .select(
+            new QReviewResponse_SearchPostForReviewDto(experience.id,
+                Expressions.stringTemplate("'{0}'", Category.EXPERIENCE),
+                experienceTrans.title, experience.firstImageFile, experienceTrans.address))
+        .from(experience)
+        .leftJoin(experienceTrans)
+        .on(experienceTrans.language.eq(language))
+        .fetch();
   }
 
   private List<Long> getIdListContainAllHashtags(String keyword, Language language) {

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.jeju.nanaland.domain.restaurant.dto.RestaurantCompositeDto;
 import com.jeju.nanaland.domain.restaurant.dto.RestaurantResponse.RestaurantMenuDto;
 import com.jeju.nanaland.domain.restaurant.dto.RestaurantResponse.RestaurantThumbnail;
 import com.jeju.nanaland.domain.restaurant.entity.enums.RestaurantTypeKeyword;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.domain.Page;
@@ -20,4 +21,6 @@ public interface RestaurantRepositoryCustom {
   Set<RestaurantTypeKeyword> getRestaurantTypeKeywordSet(Long postId);
 
   List<RestaurantMenuDto> getRestaurantMenuList(Long postId, Language language);
+
+  List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language);
 }

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.jeju.nanaland.domain.restaurant.entity.QRestaurantKeyword.rest
 import static com.jeju.nanaland.domain.restaurant.entity.QRestaurantMenu.restaurantMenu;
 import static com.jeju.nanaland.domain.restaurant.entity.QRestaurantTrans.restaurantTrans;
 
+import com.jeju.nanaland.domain.common.data.Category;
 import com.jeju.nanaland.domain.common.data.Language;
 import com.jeju.nanaland.domain.restaurant.dto.QRestaurantCompositeDto;
 import com.jeju.nanaland.domain.restaurant.dto.QRestaurantResponse_RestaurantMenuDto;
@@ -14,8 +15,11 @@ import com.jeju.nanaland.domain.restaurant.dto.RestaurantCompositeDto;
 import com.jeju.nanaland.domain.restaurant.dto.RestaurantResponse.RestaurantMenuDto;
 import com.jeju.nanaland.domain.restaurant.dto.RestaurantResponse.RestaurantThumbnail;
 import com.jeju.nanaland.domain.restaurant.entity.enums.RestaurantTypeKeyword;
+import com.jeju.nanaland.domain.review.dto.QReviewResponse_SearchPostForReviewDto;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Collections;
@@ -142,5 +146,18 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
     } else {
       return restaurantKeyword.restaurantTypeKeyword.in(keywordFilterList);
     }
+  }
+
+  @Override
+  public List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language) {
+    return queryFactory
+        .select(
+            new QReviewResponse_SearchPostForReviewDto(restaurant.id,
+                Expressions.constant(Category.RESTAURANT.name()),
+                restaurantTrans.title, restaurant.firstImageFile, restaurantTrans.address))
+        .from(restaurant)
+        .innerJoin(restaurant.restaurantTrans, restaurantTrans)
+        .where(restaurantTrans.language.eq(language))
+        .fetch();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
@@ -14,9 +14,8 @@ import com.jeju.nanaland.domain.review.dto.ReviewResponse.MemberReviewListDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.MemberReviewPreviewDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.MyReviewDetailDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewListDto;
-import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
-import com.jeju.nanaland.domain.review.dto.ReviewResponse.StatusDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewStatusDto;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import com.jeju.nanaland.domain.review.service.ReviewService;
 import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.auth.AuthMember;
@@ -179,20 +178,18 @@ public class ReviewController {
   }
 
 
-
   @Operation(summary = "자동완성 테스트")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 데이터인 경우", content = @Content)
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
-  @PostMapping("/test")
+  @PostMapping("/search/auto-complete")
   public BaseResponse<List<SearchPostForReviewDto>> toggleReviewHeart(
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestParam String keyword) {
-    List<SearchPostForReviewDto> autoCompleteSearchResultForReview = reviewService.getAutoCompleteSearchResultForReview(
-        memberInfoDto, keyword);
-    return BaseResponse.success(REVIEW_HEART_SUCCESS, autoCompleteSearchResultForReview);
+    return BaseResponse.success(REVIEW_HEART_SUCCESS,
+        reviewService.getAutoCompleteSearchResultForReview(
+            memberInfoDto, keyword));
   }
 
 

--- a/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
@@ -101,9 +101,9 @@ public class ReviewController {
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestParam String keyword) {
     List<SearchPostForReviewDto> autoCompleteSearchResultForReview = reviewService.getAutoCompleteSearchResultForReview(
-        keyword);
+        memberInfoDto, keyword);
     return BaseResponse.success(REVIEW_HEART_SUCCESS, autoCompleteSearchResultForReview);
   }
-  
+
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
@@ -178,7 +178,7 @@ public class ReviewController {
   }
 
 
-  @Operation(summary = "자동완성 테스트")
+  @Operation(summary = "리뷰위한 게시글 검색 자동완성")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)

--- a/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import com.jeju.nanaland.domain.common.data.Category;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.review.dto.ReviewRequest;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewListDto;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.StatusDto;
 import com.jeju.nanaland.domain.review.service.ReviewService;
 import com.jeju.nanaland.global.BaseResponse;
@@ -88,4 +89,21 @@ public class ReviewController {
     StatusDto statusDto = reviewService.toggleReviewHeart(memberInfoDto, id);
     return BaseResponse.success(REVIEW_HEART_SUCCESS, statusDto);
   }
+
+  @Operation(summary = "자동완성 테스트")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 데이터인 경우", content = @Content)
+  })
+  @PostMapping("/test")
+  public BaseResponse<List<SearchPostForReviewDto>> toggleReviewHeart(
+      @AuthMember MemberInfoDto memberInfoDto,
+      @RequestParam String keyword) {
+    List<SearchPostForReviewDto> autoCompleteSearchResultForReview = reviewService.getAutoCompleteSearchResultForReview(
+        keyword);
+    return BaseResponse.success(REVIEW_HEART_SUCCESS, autoCompleteSearchResultForReview);
+  }
+  
+
 }

--- a/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class ReviewResponse {
 
@@ -84,4 +85,30 @@ public class ReviewResponse {
     @Schema(description = "좋아요 상태")
     private boolean isReviewHeart;
   }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "리뷰 작성위한 게시물 검색")
+  public static class SearchPostForReviewDto {
+
+    @Schema(description = "리뷰 게시물 id")
+    private Long id;
+
+    @Schema(description = "게시물 카테고리")
+    private String category;
+
+    @Schema(description = "게시물 제목")
+    private String title;
+
+    @Schema(description = "게시물 썸네일")
+    private ImageFileDto firstImage;
+
+    @Schema(description = "리뷰 총 개수")
+    private String address;
+
+
+  }
+
 }

--- a/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class ReviewResponse {
 
@@ -184,6 +185,7 @@ public class ReviewResponse {
   }
 
   @Getter
+  @Setter
   @Builder
   @NoArgsConstructor
   @AllArgsConstructor
@@ -193,8 +195,11 @@ public class ReviewResponse {
     @Schema(description = "리뷰 게시물 id")
     private Long id;
 
-    @Schema(description = "게시물 카테고리")
+    @Schema(description = "게시물 카테고리 ex) RESTAURANT, EXPERIENCE")
     private String category;
+
+    @Schema(description = "게시물 카테고리 이름, 화면에 사용할 값(언어별 번역 제공) ex) 제주 맛집,,,")
+    private String categoryValue;
 
     @Schema(description = "게시물 제목")
     private String title;

--- a/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.domain.review.dto;
 
 import com.jeju.nanaland.domain.common.dto.ImageFileDto;
+import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
@@ -108,7 +109,15 @@ public class ReviewResponse {
     @Schema(description = "리뷰 총 개수")
     private String address;
 
-
+    @QueryProjection
+    public SearchPostForReviewDto(Long id, String category, String title, ImageFile firstImage,
+        String address) {
+      this.id = id;
+      this.category = category;
+      this.title = title;
+      this.firstImage = new ImageFileDto(firstImage.getOriginUrl(), firstImage.getThumbnailUrl());
+      this.address = address;
+    }
   }
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/dto/ReviewResponse.java
@@ -106,7 +106,7 @@ public class ReviewResponse {
     @Schema(description = "게시물 썸네일")
     private ImageFileDto firstImage;
 
-    @Schema(description = "리뷰 총 개수")
+    @Schema(description = "게시물 주소")
     private String address;
 
     @QueryProjection

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -277,12 +277,18 @@ public class ReviewService {
 
     for (Language language : Language.values()) {
       experienceRepository.findAllSearchPostForReviewDtoByLanguage(language)
-          .forEach(dto -> hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
-              dto.getTitle(), dto));
+          .forEach(dto -> {
+            dto.setCategoryValue(Category.EXPERIENCE.getValueByLocale(language));
+            hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
+                dto.getTitle(), dto);
+          });
 
       restaurantRepository.findAllSearchPostForReviewDtoByLanguage(language)
-          .forEach(dto -> hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
-              dto.getTitle(), dto));
+          .forEach(dto -> {
+            dto.setCategoryValue(Category.RESTAURANT.getValueByLocale(language));
+            hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
+                dto.getTitle(), dto);
+          });
 
     }
 

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -144,6 +144,9 @@ public class ReviewService {
   // TODO : 언어별로 SEARCH_AUTO_COMPLETE_HASH_KEY
   @PostConstruct
   private void init() {
+    if ("test".equals(System.getProperty("spring.profiles.active"))) {
+      return;
+    }
     System.out.println("***************************************");
     HashOperations<String, String, SearchPostForReviewDto> hashOperations = redisTemplate.opsForHash();
 

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -147,7 +147,6 @@ public class ReviewService {
     if ("test".equals(System.getProperty("spring.profiles.active"))) {
       return;
     }
-    System.out.println("***************************************");
     HashOperations<String, String, SearchPostForReviewDto> hashOperations = redisTemplate.opsForHash();
 
     /**

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -8,7 +8,6 @@ import static com.jeju.nanaland.global.exception.ErrorCode.REVIEW_NOT_FOUND;
 
 import com.jeju.nanaland.domain.common.data.Category;
 import com.jeju.nanaland.domain.common.data.Language;
-import com.jeju.nanaland.domain.common.dto.ImageFileDto;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
 import com.jeju.nanaland.domain.experience.repository.ExperienceRepository;
@@ -146,30 +145,49 @@ public class ReviewService {
   private void init() {
     System.out.println("***************************************");
     HashOperations<String, String, SearchPostForReviewDto> hashOperations = redisTemplate.opsForHash();
-    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + Language.KOREAN, "가나박물관, tag값",
-        SearchPostForReviewDto.builder()
-            .title("가나박물관")
-            .id(1L)
-            .category("category1")
-            .address("address1")
-            .firstImage(new ImageFileDto("image1", "image2"))
-            .build());
-    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN", "다라박물관",
-        SearchPostForReviewDto.builder()
-            .title("다라박물관")
-            .id(2L)
-            .category("category2")
-            .address("address2")
-            .firstImage(new ImageFileDto("image3", "image4"))
-            .build());
-    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN", "마바박물관",
-        SearchPostForReviewDto.builder()
-            .title("마바박물관")
-            .id(3L)
-            .category("category3")
-            .address("address3")
-            .firstImage(new ImageFileDto("image5", "image6"))
-            .build());
+
+    /**
+     * 테스트 용
+     */
+//    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + Language.KOREAN, "가나박물관, tag값",
+//        SearchPostForReviewDto.builder()
+//            .title("가나박물관")
+//            .id(1L)
+//            .category("category1")
+//            .address("address1")
+//            .firstImage(new ImageFileDto("image1", "image2"))
+//            .build());
+//    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN", "다라박물관",
+//        SearchPostForReviewDto.builder()
+//            .title("다라박물관")
+//            .id(2L)
+//            .category("category2")
+//            .address("address2")
+//            .firstImage(new ImageFileDto("image3", "image4"))
+//            .build());
+//    hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN", "마바박물관",
+//        SearchPostForReviewDto.builder()
+//            .title("마바박물관")
+//            .id(3L)
+//            .category("category3")
+//            .address("address3")
+//            .firstImage(new ImageFileDto("image5", "image6"))
+//            .build());
+
+    // ---------------------------------------
+
+    for (Language language : Language.values()) {
+      experienceRepository.findAllSearchPostForReviewDtoByLanguage(language)
+          .forEach(dto -> hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
+              dto.getTitle(), dto));
+
+      // TODO 맛집 추가시 완성하기
+//      restaurantRepository.findAllSearchPostForReviewDtoByLanguage(language)
+//          .forEach(dto -> hashOperations.put(SEARCH_AUTO_COMPLETE_HASH_KEY + language.name(),
+//              dto.getTitle(), dto));
+
+    }
+
     Long test = hashOperations.size(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN");
     System.out.println("test = " + test);
   }

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -124,15 +124,16 @@ public class ReviewService {
     }
   }
 
-  public List<SearchPostForReviewDto> getAutoCompleteSearchResultForReview(String keyword) {
+  public List<SearchPostForReviewDto> getAutoCompleteSearchResultForReview(
+      MemberInfoDto memberInfoDto, String keyword) {
     HashOperations<String, String, SearchPostForReviewDto> hashOperations = redisTemplate.opsForHash();
-    Map<String, SearchPostForReviewDto> test = hashOperations.entries(
-        SEARCH_AUTO_COMPLETE_HASH_KEY); // 여기 KEY를 나중에 language를 붙이면 될듯
+    Map<String, SearchPostForReviewDto> redisMap = hashOperations.entries(
+        SEARCH_AUTO_COMPLETE_HASH_KEY + memberInfoDto.getLanguage()
+            .name()); // 여기 KEY를 나중에 language를 붙이면 될듯
     List<SearchPostForReviewDto> dtoList = new ArrayList<>();
-    System.out.println("test.keySet().toString() = " + test.keySet().toString());
-    for (String key : test.keySet()) {
+    for (String key : redisMap.keySet()) {
       if (key.contains(keyword)) {
-        dtoList.add(test.get(key));
+        dtoList.add(redisMap.get(key));
       }
     }
     // title 사전 순으로 정렬

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -517,8 +517,6 @@ public class ReviewService {
 
     }
 
-    Long test = hashOperations.size(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN");
-    System.out.println("test = " + test);
   }
 
   /**

--- a/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jeju/nanaland/domain/review/service/ReviewService.java
@@ -36,9 +36,8 @@ import com.jeju.nanaland.domain.review.dto.ReviewResponse.MyReviewDetailDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.MyReviewDetailDto.MyReviewImageDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewDetailDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewListDto;
-import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
-import com.jeju.nanaland.domain.review.dto.ReviewResponse.StatusDto;
 import com.jeju.nanaland.domain.review.dto.ReviewResponse.ReviewStatusDto;
+import com.jeju.nanaland.domain.review.dto.ReviewResponse.SearchPostForReviewDto;
 import com.jeju.nanaland.domain.review.entity.Review;
 import com.jeju.nanaland.domain.review.entity.ReviewHeart;
 import com.jeju.nanaland.domain.review.entity.ReviewImageFile;
@@ -60,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -521,22 +519,6 @@ public class ReviewService {
 
     Long test = hashOperations.size(SEARCH_AUTO_COMPLETE_HASH_KEY + "KOREAN");
     System.out.println("test = " + test);
-  }
-
-  private Post getPostById(Long id, Category category) {
-    switch (category) {
-      case EXPERIENCE -> {
-        return experienceRepository.findById(id)
-            .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND.getMessage()));
-      }
-
-      case RESTAURANT -> {
-        return restaurantRepository.findById(id)
-            .orElseThrow(() -> new NotFoundException(POST_NOT_FOUND.getMessage()));
-      }
-
-      default -> throw new BadRequestException(CATEGORY_NOT_FOUND.getMessage());
-    }
   }
 
   /**

--- a/src/main/java/com/jeju/nanaland/global/config/RedisConfig.java
+++ b/src/main/java/com/jeju/nanaland/global/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -39,6 +40,16 @@ public class RedisConfig {
     RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> objectRedisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setDefaultSerializer(
+        new GenericJackson2JsonRedisSerializer()); // 예시로 Jackson Serializer 사용
     return redisTemplate;
   }
 }


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- @PostConstruct 를 사용해 스프링이 켜질 때 experience 를 검색 dto에 맞게 hash로 key 는 title(대면 미팅 후 카테고리 추가예정) - value는 검색 리스트 반환할 dto로 저장
- api 요청이 올 경우 언어에 맞는 hashtable에서 모든 key 가져와서 contains로 검색 후 사전 순으로 정렬하여 return
- 사용자 입력, 사용자 입력에서 공백 제거, 사용자 입력 공백으로 구분하여 각각 검색 후 사전 순으로 정렬 하고 중복 없애기
- 문제가 될 수 있는 점 -> 해당 언어의 모든 key(맛집, 이색체험의 title + 카테고리)를 가져와서 사용자의 입력과 key를 contains로 비교하다보니 n 번 반복 
  일단 괜찮다고 생각한 이유 
   1. 우리의 데이터가 많지 않다 /
   2. 다른 사이트를 보더라도 검색 시 자동완성은 로딩 창도 보여주면서 시간이 걸려서 만약에 딜레이가 조금 있더라도 괜찮다고 판단.
- 무한 스크롤을 원하셨는데 redis에서 갖고오기 때문에 page 사용이 어려웠다. 데이터가 추가되어도 많지 않을 것 같아서 한번에 모든 데이터 보내도 괜찮을 것 같습니다.

<br>

## 💬 To Reviewers
- [ ] trie라는 자료구조를 사용하려 했습니다. (검색어 추천에 사용되는 자료구조라고 합니다.) 근데 이 방법은 접두사를 통해 추천하는 메커니즘, 우리는 중간에 단어가 일치해도 추천해줘야해서 실패 ex) 가 -> 가나다 , 나 ->나다라, 나비
- [ ] 지금 방법인 redis 개발 후 elastic search를 좀 알아보고 시도했는데 버전관련도 너무 예민하고 설치부터 쉽지 않았습니다.. 거기다가 다국어로 elastic search 적용 , ec2에 elasticsearch 구축 시간 비용을 생각해보니 하안참 걸릴 것 같아서 지금의 방법으로 일단 돌아왔습니다.

<br>

## ☑️ Related Issue
> close #306 
