### PR TITLE
[Feat] 맛집 엔티티 변경

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/entity/Restaurant.java
@@ -2,6 +2,7 @@ package com.jeju.nanaland.domain.restaurant.entity;
 
 import com.jeju.nanaland.domain.common.entity.Post;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -15,6 +16,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("RESTAURANT")
 public class Restaurant extends Post {
+
+  @Column(unique = true)
+  private String contentId;
 
   private String contact;
 

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/entity/RestaurantMenu.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/entity/RestaurantMenu.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +23,6 @@ public class RestaurantMenu extends BaseEntity {
 
   private String price;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   private ImageFile firstImageFile;
 }

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -124,7 +124,7 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
             imageFile.thumbnailUrl
         ))
         .from(restaurantMenu)
-        .innerJoin(restaurantMenu.firstImageFile, imageFile)
+        .leftJoin(restaurantMenu.firstImageFile, imageFile)
         .where(restaurantMenu.restaurantTrans.restaurant.id.eq(postId)
             .and(restaurantTrans.language.eq(language)))
         .fetch();
@@ -217,7 +217,7 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
     }
     return tokenList;
   }
-  
+
   @Override
   public List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language) {
     return queryFactory


### PR DESCRIPTION
## 📝 Description
- restaurant 엔티티 contentId 추가
- restaurantMenu, imageFIle 연관관계 ManyToOne으로 변경
- 메뉴 조회시 없는 이미지 처리를 위해 left join으로 변경

<br>

## 💬 To Reviewers
- 다른 post를 상속받는 엔티티와의 통일성, 그리고 맛집 데이터를 넣을 때, DB상의 id로 데이터를 넣는것보다 임의로 contentId를 정해서 넣어주는게 더 유지보수할 때 좋을 거 같아서 추가했습니다.
- RestaurantMenu 엔티티에서, 서로 다른 튜플(같은 메뉴 다른 언어)이 같은 imageFile 을 참조할 수 있도록 ManyToOne 연관관계로 설정했습니다.

<br>

## ☑️ Related Issue
- close #338 
