### PR TITLE
[Refactor] 맛집, 이색체험 count 쿼리 수정

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryImpl.java
@@ -143,7 +143,7 @@ public class ExperienceRepositoryImpl implements ExperienceRepositoryCustom {
         .fetch();
 
     JPAQuery<Long> countQuery = queryFactory
-        .selectDistinct(experience.count())
+        .selectDistinct(experience.countDistinct())
         .from(experience)
         .innerJoin(experience.firstImageFile, imageFile)
         .innerJoin(experience.experienceTrans, experienceTrans)

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryImpl.java
@@ -64,7 +64,7 @@ public class RestaurantRepositoryImpl implements RestaurantRepositoryCustom {
         .fetch();
 
     JPAQuery<Long> countQuery = queryFactory
-        .selectDistinct(restaurant.count())
+        .selectDistinct(restaurant.countDistinct())
         .from(restaurant)
         .innerJoin(restaurant.firstImageFile, imageFile)
         .innerJoin(restaurant.restaurantTrans, restaurantTrans)


### PR DESCRIPTION
## 📝 Description
- 맛집, 이색체험 count 쿼리 수정

<br>

## 💬 To Reviewers
- 리스트 조회 시 필터링 부분에서 keyword 조건 때문에 join을 했을 때, 키워드가 여러 개인 경우 실제 자료보다 count 쿼리의 수가 더 많아지는 부분이 있었습니다. 따라서 countDistinct를 사용했습니다.

<br>

## ☑️ Related Issue
- close #348 
