### PR TITLE
Refactor/#389 s3 image service

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/service/ImageFileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/service/ImageFileService.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ImageFileService {
 
+  @Value("${cloud.aws.s3.memberProfileDirectory}")
+  private String MEMBER_PROFILE_DIRECTORY;
   private final S3ImageService s3ImageService;
   private final ImageFileRepository imageFileRepository;
 
@@ -33,16 +36,6 @@ public class ImageFileService {
         .thumbnailUrl(s3ImageDto.getThumbnailUrl())
         .build();
     return imageFileRepository.save(imageFile);
-  }
-
-  public ImageFile uploadAndSaveImageFile(MultipartFile multipartFile, boolean autoThumbnail) {
-    try {
-      S3ImageDto s3ImageDto = s3ImageService.uploadOriginImageToS3(multipartFile, autoThumbnail);
-      return saveS3ImageFile(s3ImageDto);
-    } catch (IOException e) {
-      e.printStackTrace();
-      throw new ServerErrorException(ErrorCode.SERVER_ERROR.getMessage());
-    }
   }
 
   // S3에 저장될 경로 지정
@@ -60,7 +53,7 @@ public class ImageFileService {
 
   public ImageFile getRandomProfileImageFile() {
     String selectedProfile = defaultProfile.get(random.nextInt(defaultProfile.size()));
-    S3ImageDto s3ImageDto = s3ImageService.getS3Urls(selectedProfile);
+    S3ImageDto s3ImageDto = s3ImageService.getS3Urls(selectedProfile, MEMBER_PROFILE_DIRECTORY);
     return saveS3ImageFile(s3ImageDto);
   }
 
@@ -72,12 +65,8 @@ public class ImageFileService {
     return images;
   }
 
-  public void deleteImageFileInS3ByImageFile(ImageFile imageFile) {
-    s3ImageService.deleteImageS3(imageFile);
-  }
-
-  public void deleteImageFileInS3ByOriginUrl(String originUrl) {
-    s3ImageService.deleteImageS3ByOriginUrl(originUrl);
+  public void deleteImageFileInS3ByImageFile(ImageFile imageFile, String directoryPath) {
+    s3ImageService.deleteImageS3(imageFile, directoryPath);
   }
 
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class MemberLoginService {
 
+  @Value("${cloud.aws.s3.memberProfileDirectory}")
+  private String MEMBER_PROFILE_DIRECTORY;
   private final MemberRepository memberRepository;
   private final MemberWithdrawalRepository memberWithdrawalRepository;
   private final JwtUtil jwtUtil;
@@ -100,7 +103,7 @@ public class MemberLoginService {
     if (multipartFile == null) {
       return imageFileService.getRandomProfileImageFile();
     }
-    return imageFileService.uploadAndSaveImageFile(multipartFile, true);
+    return imageFileService.uploadAndSaveImageFile(multipartFile, true, MEMBER_PROFILE_DIRECTORY);
   }
 
   // 회원 생성

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,6 +36,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 public class MemberProfileService {
 
+  @Value("${cloud.aws.s3.memberProfileDirectory}")
+  private String MEMBER_PROFILE_DIRECTORY;
   private final S3ImageService s3ImageService;
   private final MemberRepository memberRepository;
 
@@ -48,9 +51,10 @@ public class MemberProfileService {
     ImageFile profileImageFile = member.getProfileImageFile();
     if (multipartFile != null) {
       try {
-        S3ImageDto s3ImageDto = s3ImageService.uploadOriginImageToS3(multipartFile, true);
+        S3ImageDto s3ImageDto = s3ImageService.uploadImageToS3(multipartFile, true,
+            MEMBER_PROFILE_DIRECTORY);
         if (!s3ImageService.isDefaultProfileImage(profileImageFile)) {
-          s3ImageService.deleteImageS3(profileImageFile);
+          s3ImageService.deleteImageS3(profileImageFile, MEMBER_PROFILE_DIRECTORY);
         }
         profileImageFile.updateImageFile(s3ImageDto);
       } catch (IOException e) {

--- a/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/controller/NanaController.java
@@ -1,7 +1,6 @@
 package com.jeju.nanaland.domain.nana.controller;
 
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
-import com.jeju.nanaland.domain.nana.dto.NanaRequest;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaDetailDto;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnailDto;
@@ -18,14 +17,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Slf4j
 @RestController
@@ -100,12 +96,12 @@ public class NanaController {
     return modelAndView;
   }
 
-  @PostMapping("/upload")
-  public ModelAndView createNanaPick(@ModelAttribute NanaRequest.NanaUploadDto nanaUploadDto,
-      RedirectAttributes redirectAttributes) {
-    String result = nanaService.createNanaPick(nanaUploadDto);
-
-    redirectAttributes.addFlashAttribute("result", result);
-    return new ModelAndView("redirect:/nana/upload");
-  }
+//  @PostMapping("/upload")
+//  public ModelAndView createNanaPick(@ModelAttribute NanaRequest.NanaUploadDto nanaUploadDto,
+//      RedirectAttributes redirectAttributes) {
+//    String result = nanaService.createNanaPick(nanaUploadDto);
+//
+//    redirectAttributes.addFlashAttribute("result", result);
+//    return new ModelAndView("redirect:/nana/upload");
+//  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/service/NanaService.java
@@ -4,10 +4,8 @@ import static com.jeju.nanaland.domain.common.data.Category.NANA;
 import static com.jeju.nanaland.domain.common.data.Category.NANA_CONTENT;
 import static com.jeju.nanaland.global.exception.ErrorCode.NANA_TITLE_NOT_FOUND;
 
-import com.jeju.nanaland.domain.common.data.Category;
 import com.jeju.nanaland.domain.common.data.Language;
 import com.jeju.nanaland.domain.common.dto.ImageFileDto;
-import com.jeju.nanaland.domain.common.entity.PostImageFile;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.common.repository.PostImageFileRepository;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
@@ -16,7 +14,6 @@ import com.jeju.nanaland.domain.hashtag.entity.Hashtag;
 import com.jeju.nanaland.domain.hashtag.repository.HashtagRepository;
 import com.jeju.nanaland.domain.hashtag.service.HashtagService;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
-import com.jeju.nanaland.domain.nana.dto.NanaRequest;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnail;
 import com.jeju.nanaland.domain.nana.dto.NanaResponse.NanaThumbnailDto;
@@ -40,7 +37,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -48,9 +44,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.interceptor.TransactionAspectSupport;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -218,111 +211,111 @@ public class NanaService {
     return result;
   }
 
-  // 나나스픽 생성
-  // TODO : 모듈화한 부분이니 제거해도 괜찮을 것 같아보임
-  @Transactional
-  public String createNanaPick(NanaRequest.NanaUploadDto nanaUploadDto) {
-    try {
-      boolean existNanaContentImages = false;
-      Nana nana;
-      Long nanaId = nanaUploadDto.getPostId();
-      Language language = Language.valueOf(nanaUploadDto.getLanguage());
-      Category category = NANA_CONTENT;
-
-      // 없는 nana이면 nana 만들기
-      if (!existNanaById(nanaId)) {
-
-        // 처음 생성되는 나나's pick이면 KOREAN 버전부터 생성되어야 함
-        if (!Objects.equals(nanaUploadDto.getLanguage(), "KOREAN")) {
-          throw new BadRequestException("처음 생성하는 Nana's pick은 KOREAN 버전부터 입력해야합니다.");
-        }
-        // 처음 생성하는 nana인데 title image 없을 경우 에러
-        if (nanaUploadDto.getNanaTitleImage().isEmpty()) {
-          throw new BadRequestException("처음 생성하는 Nana's pick에는 title 이미지가 필수입니다.");
-        }
-        // nana 생성해서 저장하기
-        nana = createNanaByNanaUploadDto(nanaUploadDto);
-      } else {// 이미 존재하는 nana인 경우
-        nana = getNanaById(nanaId);
-
-        //존재하는 nana일 경우 해당 post가 이미 작성된 language로 요청이 올 경우 에러
-        if (existNanaTitleByNanaAndLanguage(nana, language)) {
-          throw new BadRequestException("이미 존재하는 NanaTitle의 Language입니다");
-        }
-
-        // 이미 nanaTitle이 존재하면 nanaContentImage 추가 생성 필요 없음을 표시
-        if (existNanaTitleByNana(nana)) {
-          existNanaContentImages = true;
-        }
-
-        /*
-         * 이미 존재하는 경우 한국어 버전 NanaContent의 수와 비교한다.
-         * (nanaContent들은 KOREAN nana Content의 사진들 공유 하기 때문에 기준은 KOREAN 버전)
-         * 기존의 content 수와 새로 요청한 content 게시글 수가 일치하지 않을 때
-         */
-        if (countKoreanNanaContents(nana)
-            != nanaUploadDto.getNanaContents().size()) {
-          throw new BadRequestException(
-              "기존의 nana content 수와 현재 요청한 nana content의 수가 일치하지 않습니다.");
-        }
-      }
-
-      NanaTitle nanaTitle = NanaTitle.builder()
-          .nana(nana)
-          .language(language)
-          .subHeading(nanaUploadDto.getSubHeading())
-          .heading(nanaUploadDto.getHeading())
-          .notice(nanaUploadDto.getNotice())
-          .build();
-      nanaTitleRepository.save(nanaTitle);
-
-//      람다 안에서 외부 변수를 사용하기 위해서는 effectively final 변수를 사용해야하므로 선언
-//      존재할 경우 flag -> false / 존재하지 않을 경우 flag -> true
-      boolean createNanaContentsImageFlag = !existNanaContentImages;
-
-      // 람다 시작
-      //content 생성
-      nanaUploadDto.getNanaContents().forEach(nanaContentDto -> {
-            NanaContent nanaContent = nanaContentRepository.save(NanaContent.builder()
-                .nanaTitle(nanaTitle)
-                .priority((long) nanaContentDto.getNumber())
-                .subTitle(nanaContentDto.getSubTitle())
-                .title(nanaContentDto.getTitle())
-                .content(nanaContentDto.getContent())
-                .infoList(createNanaAdditionalInfo(nanaContentDto.getAdditionalInfo(),
-                    nanaContentDto.getInfoDesc()))
-                .build());
-
-            if (createNanaContentsImageFlag) { // nanaContentImage가 존재하지 않을 경우에만 추가.
-              // 람다 안에 들어있으니 nanaContent 1개에 대한 사진 묶음
-              List<MultipartFile> nanaContentImages = nanaContentDto.getNanaContentImages();
-              if (nanaContentImages.isEmpty()) {
-                throw new BadRequestException("처음 생성하는 Nana's pick에는 content 이미지가 필수입니다. ");
-              }
-              // nanaContent 하나 당 여러 개의 이미지 처리
-              List<PostImageFile> postImageFiles = nanaContentImages.stream()
-                  .map(image -> PostImageFile.builder()
-                      .imageFile(imageFileService.uploadAndSaveImageFile(image, false))
-                      .post(nanaContent)
-                      .build())
-                  .collect(Collectors.toList());
-
-              postImageFileRepository.saveAll(postImageFiles);
-            }
-
-            //해시태그 생성
-            hashtagService.registerHashtag(nanaContentDto.getHashtag(),
-                language, category, nanaContent);
-          } // 람다 끝
-      );
-    } catch (Exception e) {
-      // 외부 메서드 호출 시 에러 터지면 롤백
-      TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
-      return e.getMessage();
-    }
-    return "성공~";
-
-  }
+//  // 나나스픽 생성
+//  // TODO : 모듈화한 부분이니 제거해도 괜찮을 것 같아보임
+//  @Transactional
+//  public String createNanaPick(NanaRequest.NanaUploadDto nanaUploadDto) {
+//    try {
+//      boolean existNanaContentImages = false;
+//      Nana nana;
+//      Long nanaId = nanaUploadDto.getPostId();
+//      Language language = Language.valueOf(nanaUploadDto.getLanguage());
+//      Category category = NANA_CONTENT;
+//
+//      // 없는 nana이면 nana 만들기
+//      if (!existNanaById(nanaId)) {
+//
+//        // 처음 생성되는 나나's pick이면 KOREAN 버전부터 생성되어야 함
+//        if (!Objects.equals(nanaUploadDto.getLanguage(), "KOREAN")) {
+//          throw new BadRequestException("처음 생성하는 Nana's pick은 KOREAN 버전부터 입력해야합니다.");
+//        }
+//        // 처음 생성하는 nana인데 title image 없을 경우 에러
+//        if (nanaUploadDto.getNanaTitleImage().isEmpty()) {
+//          throw new BadRequestException("처음 생성하는 Nana's pick에는 title 이미지가 필수입니다.");
+//        }
+//        // nana 생성해서 저장하기
+//        nana = createNanaByNanaUploadDto(nanaUploadDto);
+//      } else {// 이미 존재하는 nana인 경우
+//        nana = getNanaById(nanaId);
+//
+//        //존재하는 nana일 경우 해당 post가 이미 작성된 language로 요청이 올 경우 에러
+//        if (existNanaTitleByNanaAndLanguage(nana, language)) {
+//          throw new BadRequestException("이미 존재하는 NanaTitle의 Language입니다");
+//        }
+//
+//        // 이미 nanaTitle이 존재하면 nanaContentImage 추가 생성 필요 없음을 표시
+//        if (existNanaTitleByNana(nana)) {
+//          existNanaContentImages = true;
+//        }
+//
+//        /*
+//         * 이미 존재하는 경우 한국어 버전 NanaContent의 수와 비교한다.
+//         * (nanaContent들은 KOREAN nana Content의 사진들 공유 하기 때문에 기준은 KOREAN 버전)
+//         * 기존의 content 수와 새로 요청한 content 게시글 수가 일치하지 않을 때
+//         */
+//        if (countKoreanNanaContents(nana)
+//            != nanaUploadDto.getNanaContents().size()) {
+//          throw new BadRequestException(
+//              "기존의 nana content 수와 현재 요청한 nana content의 수가 일치하지 않습니다.");
+//        }
+//      }
+//
+//      NanaTitle nanaTitle = NanaTitle.builder()
+//          .nana(nana)
+//          .language(language)
+//          .subHeading(nanaUploadDto.getSubHeading())
+//          .heading(nanaUploadDto.getHeading())
+//          .notice(nanaUploadDto.getNotice())
+//          .build();
+//      nanaTitleRepository.save(nanaTitle);
+//
+////      람다 안에서 외부 변수를 사용하기 위해서는 effectively final 변수를 사용해야하므로 선언
+////      존재할 경우 flag -> false / 존재하지 않을 경우 flag -> true
+//      boolean createNanaContentsImageFlag = !existNanaContentImages;
+//
+//      // 람다 시작
+//      //content 생성
+//      nanaUploadDto.getNanaContents().forEach(nanaContentDto -> {
+//            NanaContent nanaContent = nanaContentRepository.save(NanaContent.builder()
+//                .nanaTitle(nanaTitle)
+//                .priority((long) nanaContentDto.getNumber())
+//                .subTitle(nanaContentDto.getSubTitle())
+//                .title(nanaContentDto.getTitle())
+//                .content(nanaContentDto.getContent())
+//                .infoList(createNanaAdditionalInfo(nanaContentDto.getAdditionalInfo(),
+//                    nanaContentDto.getInfoDesc()))
+//                .build());
+//
+//            if (createNanaContentsImageFlag) { // nanaContentImage가 존재하지 않을 경우에만 추가.
+//              // 람다 안에 들어있으니 nanaContent 1개에 대한 사진 묶음
+//              List<MultipartFile> nanaContentImages = nanaContentDto.getNanaContentImages();
+//              if (nanaContentImages.isEmpty()) {
+//                throw new BadRequestException("처음 생성하는 Nana's pick에는 content 이미지가 필수입니다. ");
+//              }
+//              // nanaContent 하나 당 여러 개의 이미지 처리
+//              List<PostImageFile> postImageFiles = nanaContentImages.stream()
+//                  .map(image -> PostImageFile.builder()
+//                      .imageFile(imageFileService.uploadAndSaveImageFile(image, false))
+//                      .post(nanaContent)
+//                      .build())
+//                  .collect(Collectors.toList());
+//
+//              postImageFileRepository.saveAll(postImageFiles);
+//            }
+//
+//            //해시태그 생성
+//            hashtagService.registerHashtag(nanaContentDto.getHashtag(),
+//                language, category, nanaContent);
+//          } // 람다 끝
+//      );
+//    } catch (Exception e) {
+//      // 외부 메서드 호출 시 에러 터지면 롤백
+//      TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+//      return e.getMessage();
+//    }
+//    return "성공~";
+//
+//  }
 
   // nanaContent의 AdditionalInfo dto로 바꾸기
   private List<NanaResponse.NanaAdditionalInfo> getAdditionalInfoFromNanaContentEntity(
@@ -368,14 +361,14 @@ public class NanaService {
     return nanaTitleRepository.existsByNanaAndLanguage(nana, language);
   }
 
-  private Nana createNanaByNanaUploadDto(NanaRequest.NanaUploadDto nanaUploadDto) {
-    return Nana.builder()
-        .version("Nana's Pick vol." + nanaUploadDto.getVersion())
-        .priority((long) nanaUploadDto.getVersion())
-        .firstImageFile(imageFileService.uploadAndSaveImageFile(nanaUploadDto.getNanaTitleImage(),
-            false))
-        .build();
-  }
+//  private Nana createNanaByNanaUploadDto(NanaRequest.NanaUploadDto nanaUploadDto) {
+//    return Nana.builder()
+//        .version("Nana's Pick vol." + nanaUploadDto.getVersion())
+//        .priority((long) nanaUploadDto.getVersion())
+//        .firstImageFile(imageFileService.uploadAndSaveImageFile(nanaUploadDto.getNanaTitleImage(),
+//            false))
+//        .build();
+//  }
 
   private Nana getNanaById(Long id) {
     return nanaRepository.findNanaById(id)

--- a/src/main/java/com/jeju/nanaland/domain/report/service/ReportService.java
+++ b/src/main/java/com/jeju/nanaland/domain/report/service/ReportService.java
@@ -305,7 +305,7 @@ public class ReportService {
     List<ClaimReportVideoFile> videoFileList = new ArrayList<>();
     for (MultipartFile video : videoFiles) {
       VideoFile videoFile = videoFileService.uploadAndSaveVideoFile(video,
-          ReportService.CLAIM_REPORT_FILE_DIRECTORY);
+          CLAIM_REPORT_FILE_DIRECTORY);
 
       videoFileList.add(ClaimReportVideoFile.builder()
           .videoFile(videoFile)

--- a/src/main/java/com/jeju/nanaland/domain/report/service/ReportService.java
+++ b/src/main/java/com/jeju/nanaland/domain/report/service/ReportService.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -70,8 +71,10 @@ public class ReportService {
   private static final int MAX_IMAGE_COUNT = 5;
   // TODO: 관리자 계정으로 바꾸기
   private static final String ADMIN_EMAIL = "jyajoo1020@gmail.com";
-  private static final String INFO_FIX_REPORT_IMAGE_DIRECTORY = "/info_fix_report_images";
-  private static final String CLAIM_REPORT_FILE_DIRECTORY = "/claim_report_files";
+  @Value("${cloud.aws.s3.infoFixReportImageDirectory}")
+  private String INFO_FIX_REPORT_IMAGE_DIRECTORY;
+  @Value("${cloud.aws.s3.claimReportFileDirectory}")
+  private String CLAIM_REPORT_FILE_DIRECTORY;
   private final MemberRepository memberRepository;
   private final ClaimReportVideoFileRepository claimReportVideoFileRepository;
   private final ClaimReportRepository claimReportRepository;

--- a/src/test/java/com/jeju/nanaland/domain/member/service/MemberLoginServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/member/service/MemberLoginServiceTest.java
@@ -193,7 +193,7 @@ class MemberLoginServiceTest {
         .when(memberRepository).findByProviderAndProviderId(any(Provider.class), any());
     doReturn(Optional.empty()).when(memberRepository).findByNickname(any());
     doReturn(imageFile).when(imageFileService).getRandomProfileImageFile();
-    doReturn(imageFile).when(imageFileService).uploadAndSaveImageFile(any(), anyBoolean());
+    doReturn(imageFile).when(imageFileService).uploadAndSaveImageFile(any(), anyBoolean(), any());
     doReturn(member).when(memberRepository).save(any());
     doReturn("accessToken").when(jwtUtil).getAccessToken(any(), any());
     doReturn("refreshToken").when(jwtUtil).getRefreshToken(any(), any());
@@ -215,7 +215,7 @@ class MemberLoginServiceTest {
     verify(memberRepository, times(2)).findByProviderAndProviderId(any(Provider.class), any());
     verify(memberRepository, times(2)).findByNickname(any());
     verify(imageFileService, times(1)).getRandomProfileImageFile();
-    verify(imageFileService, times(1)).uploadAndSaveImageFile(any(), anyBoolean());
+    verify(imageFileService, times(1)).uploadAndSaveImageFile(any(), anyBoolean(), any());
     verify(memberRepository, times(2)).save(any());
     verify(jwtUtil, times(2)).getAccessToken(any(), any());
     verify(jwtUtil, times(2)).getRefreshToken(any(), any());

--- a/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
@@ -3,6 +3,7 @@ package com.jeju.nanaland.domain.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -141,7 +142,8 @@ class MemberProfileServiceTest {
         .build();
 
     doReturn(Optional.empty()).when(memberRepository).findByNickname(any());
-    doReturn(s3ImageDto).when(s3ImageService).uploadOriginImageToS3(multipartFile, true);
+    doReturn(s3ImageDto).when(s3ImageService)
+        .uploadImageToS3(any(MultipartFile.class), eq(true), any());
 
     // when
     memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, multipartFile);

--- a/src/test/java/com/jeju/nanaland/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/report/service/ReportServiceTest.java
@@ -196,7 +196,7 @@ class ReportServiceTest {
     doReturn(NatureCompositeDto.builder().build()).when(natureRepository)
         .findCompositeDtoById(1L, Language.KOREAN);
     doReturn(mock(ImageFile.class)).when(imageFileService)
-        .uploadAndSaveImageFile(any(MultipartFile.class), eq(false), eq("/info_fix_report_images"));
+        .uploadAndSaveImageFile(any(MultipartFile.class), eq(false), any());
     doReturn(mock(MimeMessage.class)).when(javaMailSender).createMimeMessage();
     doReturn("nanaland.jeju@gmail.com").when(env).getProperty("spring.mail.username");
     doReturn(null).when(infoFixReportRepository).save(any(InfoFixReport.class));


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- javadoc 작성
- 불필요한 메서드 삭제
- post 이미지들만 /images에 저장
- /member_profile, /review, /test 디렉토리 s3에 생성
- 로컬, dev 환경에는 /test로 생성되는 사진 저장되도록

<br>

## 💬 To Reviewers
- [ ] 유저 default 이미지는 복제해서 /member_profile에도 넣어두었습니다.
- [ ] 지금까지 저장되어있는 user profile을 /member_profile로 이동하는 작업을 출시 전에 해야할 것 같습니다.

<br>

## ☑️ Related Issue
> 관련 이슈
close #389
