### PR TITLE
[Hotfix] 찜리스트 정렬기준 변경

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryCustom.java
@@ -9,9 +9,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface FavoriteRepositoryCustom {
 
-  Page<Favorite> findAllFavoritesOrderByCreatedAtDesc(Member member, Pageable pageable);
+  Page<Favorite> findAllFavoritesOrderByModifiedAtDesc(Member member, Pageable pageable);
 
-  Page<Favorite> findAllFavoritesOrderByCreatedAtDesc(Member member, Category category,
+  Page<Favorite> findAllFavoritesOrderByModifiedAtDesc(Member member, Category category,
       Pageable pageable);
 
   List<Favorite> findAllFavoriteToSendNotification();

--- a/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -21,14 +21,14 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
   private final JPAQueryFactory queryFactory;
 
   @Override
-  public Page<Favorite> findAllFavoritesOrderByCreatedAtDesc(Member member, Pageable pageable) {
+  public Page<Favorite> findAllFavoritesOrderByModifiedAtDesc(Member member, Pageable pageable) {
     List<Favorite> resultDto = queryFactory
         .selectFrom(favorite)
         .where(
             favorite.member.eq(member),
             favorite.status.eq("ACTIVE")
         )
-        .orderBy(favorite.createdAt.desc())
+        .orderBy(favorite.modifiedAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();
@@ -45,7 +45,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
   }
 
   @Override
-  public Page<Favorite> findAllFavoritesOrderByCreatedAtDesc(Member member, Category category,
+  public Page<Favorite> findAllFavoritesOrderByModifiedAtDesc(Member member, Category category,
       Pageable pageable) {
     List<Favorite> resultDto = queryFactory
         .selectFrom(favorite)
@@ -54,7 +54,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
             favorite.category.eq(category),
             favorite.status.eq("ACTIVE")
         )
-        .orderBy(favorite.createdAt.desc())
+        .orderBy(favorite.modifiedAt.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();

--- a/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/jeju/nanaland/domain/favorite/service/FavoriteService.java
@@ -49,7 +49,7 @@ public class FavoriteService {
 
     // favorite 테이블에서 해당 유저의 찜리스트 페이지 조회
     Page<Favorite> favorites =
-        favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(member, pageable);
+        favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(member, pageable);
 
     // 조회된 Favorite 객체 리스트를 통해 FavoritePostCardDto 정보 가져오기
     List<FavoriteResponse.PreviewDto> favoritePreviewDtos = favorites.stream()
@@ -86,7 +86,7 @@ public class FavoriteService {
 
     // favorite 테이블에서 해당 유저의 카테고리 찜리스트 페이지 조회
     Page<Favorite> favoritePage =
-        favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(member, category, pageable);
+        favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(member, category, pageable);
 
     // 조회된 Favorite 객체 리스트를 통해 FavoritePostCardDto 정보 가져오기
     List<FavoriteResponse.PreviewDto> favoritePreviewDtos = favoritePage.get()

--- a/src/test/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/favorite/repository/FavoriteRepositoryTest.java
@@ -62,9 +62,9 @@ public class FavoriteRepositoryTest {
   }
 
   // TODO: Category 에서 NANA_CONTENT 제외
-  @DisplayName("유저 전체 찜리스트 조회, 생성 일자 내림차순 조회")
+  @DisplayName("유저 전체 찜리스트 조회, 수정 일자 내림차순 조회")
   @Test
-  void findAllFavoritesOrderByCreatedAtDescTest() {
+  void findAllFavoritesOrderByModifiedAtDescTest() {
     // given
     Member member = createMember(Language.KOREAN);
     int nanaCount = 2;
@@ -104,7 +104,7 @@ public class FavoriteRepositoryTest {
     favorites.addAll(createFavorites(member, inactiveRestaurants, Category.RESTAURANT, "INACTIVE"));
 
     // when
-    Page<Favorite> result = favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(
+    Page<Favorite> result = favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(
         member, pageable);
 
     // then
@@ -113,10 +113,10 @@ public class FavoriteRepositoryTest {
         .allMatch(status -> status.equals("ACTIVE"));
   }
 
-  @DisplayName("유저 카테고리 찜리스트 생성 일자 내림차순 조회")
+  @DisplayName("유저 카테고리 찜리스트 수정 일자 내림차순 조회")
   @ParameterizedTest
   @EnumSource(value = Category.class, names = "NANA_CONTENT", mode = Mode.EXCLUDE)
-  void findAllFavoritesOrderByCreatedAtDescTest(Category category) {
+  void findAllFavoritesOrderByModifiedAtDescTest(Category category) {
     // given
     Member member = createMember(Language.KOREAN);
     int activeRandomSize = random.nextInt(10) + 1;
@@ -136,7 +136,7 @@ public class FavoriteRepositoryTest {
     List<Favorite> inactiveFavorites = createFavorites(member, inactivePosts, category, "INACTIVE");
 
     // when
-    Page<Favorite> result = favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(
+    Page<Favorite> result = favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(
         member, category, pageable);
 
     // then

--- a/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/favorite/service/FavoriteServiceTest.java
@@ -119,7 +119,7 @@ class FavoriteServiceTest {
     favorites.addAll(createFavorites(member, experiences, Category.EXPERIENCE, "ACTIVE"));
     favorites.addAll(createFavorites(member, restaurants, Category.RESTAURANT, "ACTIVE"));
 
-    when(favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(member, pageable))
+    when(favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(member, pageable))
         .thenReturn(new PageImpl<>(favorites, pageable, favorites.size()));
     when(postService.getPostPreviewDto(nullable(Long.class), any(Category.class),
         eq(Language.KOREAN)))
@@ -151,7 +151,7 @@ class FavoriteServiceTest {
     // 찜 등록
     List<Favorite> favorites = createFavorites(member, posts, category, "ACTIVE");
 
-    when(favoriteRepository.findAllFavoritesOrderByCreatedAtDesc(member, category, pageable))
+    when(favoriteRepository.findAllFavoritesOrderByModifiedAtDesc(member, category, pageable))
         .thenReturn(new PageImpl<>(favorites, pageable, favorites.size()));
     when(postService.getPostPreviewDto(nullable(Long.class), any(Category.class),
         eq(Language.KOREAN)))


### PR DESCRIPTION
## 📝 Description
- 찜리스트 정렬 기준을 createdAt에서 modifiedAt으로 변경

<br>

## 💬 To Reviewers
- 좋아요 알림을 중복해서 보내지 않기 위해서 favorite을 ACTIVE, INACTIVE 상태로 관리합니다.
- 찜을 취소했다가 다시 눌렀을 경우 가장 첫번째로 보여져야 하지만, 기존 방법대로 created_at을 기준으로 정렬하면 값이 바뀌지 않아서 modified_at을 기준으로 정렬하도록 바꿨습니다.

<br>

## ☑️ Related Issue
> 관련 이슈
