### PR TITLE
Feat/#441 notification

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -152,7 +152,8 @@ public class MemberController {
   public BaseResponse<List<MemberResponse.RecommendPostDto>> getRecommendPostsByType(
       @AuthMember MemberInfoDto memberInfoDto) {
 
-    List<MemberResponse.RecommendPostDto> result = memberTypeService.getRecommendPostsByType(memberInfoDto);
+    List<MemberResponse.RecommendPostDto> result = memberTypeService.getRecommendPostsByType(
+        memberInfoDto);
     return BaseResponse.success(GET_RECOMMENDED_POSTS_SUCCESS, result);
   }
 
@@ -168,7 +169,8 @@ public class MemberController {
   public BaseResponse<List<MemberResponse.RecommendPostDto>> getRandomRecommendedPosts(
       @AuthMember MemberInfoDto memberInfoDto) {
 
-    List<MemberResponse.RecommendPostDto> result = memberTypeService.getRandomRecommendedPosts(memberInfoDto);
+    List<MemberResponse.RecommendPostDto> result = memberTypeService.getRandomRecommendedPosts(
+        memberInfoDto);
     return BaseResponse.success(GET_RECOMMENDED_POSTS_SUCCESS, result);
   }
 
@@ -245,12 +247,12 @@ public class MemberController {
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content)
   })
   @PostMapping("/consent")
-  public BaseResponse<Null> updateMemberConsent(
+  public BaseResponse<Boolean> updateMemberConsent(
       @AuthMember MemberInfoDto memberInfoDto,
       @RequestBody @Valid MemberRequest.ConsentUpdateDto consentUpdateDto
   ) {
-    memberConsentService.updateMemberConsent(memberInfoDto, consentUpdateDto);
-    return BaseResponse.success(UPDATE_MEMBER_CONSENT_SUCCESS);
+    boolean consent = memberConsentService.updateMemberConsent(memberInfoDto, consentUpdateDto);
+    return BaseResponse.success(UPDATE_MEMBER_CONSENT_SUCCESS, consent);
   }
 
   @Operation(

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -2,10 +2,10 @@ package com.jeju.nanaland.domain.member.dto;
 
 import com.jeju.nanaland.domain.common.annotation.EnumValid;
 import com.jeju.nanaland.domain.common.data.Language;
-import com.jeju.nanaland.domain.member.entity.enums.WithdrawalType;
 import com.jeju.nanaland.domain.member.entity.enums.ConsentType;
 import com.jeju.nanaland.domain.member.entity.enums.Provider;
 import com.jeju.nanaland.domain.member.entity.enums.TravelType;
+import com.jeju.nanaland.domain.member.entity.enums.WithdrawalType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -122,7 +122,7 @@ public class MemberRequest {
   public static class ConsentUpdateDto {
 
     @Schema(description = "이용약관", example = "MARKETING",
-        allowableValues = {"MARKETING", "LOCATION_SERVICE"})
+        allowableValues = {"MARKETING", "LOCATION_SERVICE", "NOTIFICATION"})
     @NotNull
     @EnumValid(
         enumClass = ConsentType.class,

--- a/src/main/java/com/jeju/nanaland/domain/member/entity/enums/ConsentType.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/entity/enums/ConsentType.java
@@ -1,5 +1,5 @@
 package com.jeju.nanaland.domain.member.entity.enums;
 
 public enum ConsentType {
-  TERMS_OF_USE, MARKETING, LOCATION_SERVICE
+  TERMS_OF_USE, MARKETING, LOCATION_SERVICE, NOTIFICATION
 }

--- a/src/main/java/com/jeju/nanaland/global/exception/BadRequestException.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/BadRequestException.java
@@ -6,6 +6,10 @@ public class BadRequestException extends RuntimeException {
     super(ErrorCode.BAD_REQUEST_EXCEPTION.getMessage());
   }
 
+  public BadRequestException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+  }
+
   public BadRequestException(String errorMessage) {
     super(errorMessage);
   }

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
   EDIT_REVIEW_IMAGE_INFO_BAD_REQUEST(BAD_REQUEST, "리뷰 수정 시 기존 이미지에 대한 정보가 잘못 되었습니다."),
   SELF_REPORT_NOT_ALLOWED(BAD_REQUEST, "본인을 신고하는 요청은 유효하지 않습니다."),
   ALREADY_REPORTED(BAD_REQUEST, "이미 신고되었습니다."),
+  NO_NOTIFICATION_CONSENT(BAD_REQUEST, "알림 동의를 하지 않은 유저입니다."),
 
   //INTERNAL_SERVER_ERROR
   SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버측 에러입니다."),


### PR DESCRIPTION
## 📝 Description
- 알림 동의/취소 API
- 알림 전송 시 동의 여부 체크 로직 추가

<br>

## 💬 To Reviewers
- DB의 `member_consent`중 `consent_type` 필드에 `NOTIFICATION`이 추가되어야 합니다.
- 기존에 회원가입 하면 모든 ConsentType에 대해 MemberConsentType을 생성했는데, 이미 존재하는 유저들에 대해서는 새로 생긴 NOTIFICATION 권한이 없어서 `memberConsentService`의 `updateMemberConsent` 매서드를 수정했습니다.
- 기존 로직은 없는 ConsentType이 있으면 Exception을 던졌는데, 요청 들어온 ConsentType을 생성하고 동의 여부를 변경하도록 했습니다.
- 관련해서 테스트코드도 수정했는데 실패 코드는 지우지 않고 주석처리 했습니다.

<br>

## ☑️ Related Issue
- close #441 
