### PR TITLE
[Fix] 유저 닉네임 중복 로직 수정

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -277,7 +277,7 @@ public class MemberController {
       @ApiResponse(responseCode = "409", description = "닉네임이 중복되는 경우", content = @Content)
   })
   @GetMapping("/validateNickname")
-  public BaseResponse<Null> validateNickname(
+  public BaseResponse<Void> validateNickname(
       @RequestParam String nickname,
       @RequestParam(required = false) Long memberId) {
     if (memberId == null) {

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -62,7 +62,7 @@ public class MemberRequest {
 
     @Schema(description = "닉네임(필수) - GUEST이면 GUEST로 임시 지정하여 요청")
     @NotBlank
-    @Size(max = 12, message = "닉네임 최대 길이 초과")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
     @Pattern(
         regexp = "^[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ][a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]{0,10}[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]$",
         message = "닉네임 형식이 올바르지 않습니다.")
@@ -182,7 +182,7 @@ public class MemberRequest {
 
     @Schema(description = "닉네임")
     @NotBlank
-    @Size(max = 12, message = "닉네임 최대 길이 초과")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
     @Pattern(
         regexp = "^[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ][a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]{0,10}[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]$",
         message = "닉네임 형식이 올바르지 않습니다.")

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberRequest.java
@@ -63,6 +63,9 @@ public class MemberRequest {
     @Schema(description = "닉네임(필수) - GUEST이면 GUEST로 임시 지정하여 요청")
     @NotBlank
     @Size(max = 12, message = "닉네임 최대 길이 초과")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ][a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]{0,10}[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]$",
+        message = "닉네임 형식이 올바르지 않습니다.")
     private String nickname;
 
     @Schema(description = "fcm 토큰")
@@ -180,6 +183,9 @@ public class MemberRequest {
     @Schema(description = "닉네임")
     @NotBlank
     @Size(max = 12, message = "닉네임 최대 길이 초과")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ][a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]{0,10}[a-zA-Z0-9가-힣\\u4E00-\\u9FFF\\u00C0-\\u024F\\u1E00-\\u1EFF ]$",
+        message = "닉네임 형식이 올바르지 않습니다.")
     private String nickname;
 
     @Schema(description = "소개")

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -104,8 +104,12 @@ public class MemberProfileService {
    * @throws ConflictException 닉네임이 중복되는 경우
    */
   public void validateNickname(String nickname, Member member) {
+    if (nickname.equals(member.getNickname())) {
+      return;
+    }
+
     Optional<Member> savedMember = memberRepository.findByNickname(nickname);
-    if (savedMember.isPresent() && !savedMember.get().equals(member)) {
+    if (savedMember.isPresent()) {
       throw new ConflictException(NICKNAME_DUPLICATE.getMessage());
     }
   }


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 닉네임이 중복되지 않았는데, 중복되었다는 응답이 왔다는 소식에 일단 살펴보았는데, 제 로컬에서는 해당 오류가 재현되지가 않더라구요. 일단 닉네임 중복 로직에서 불필요한 부분을 제거하고 정규식을 추가하는 작업을 하여 수정했습니다.

<br>

## 💬 To Reviewers
- [ ]

<br>

## ☑️ Related Issue
> 관련 이슈
close #447 