### PR TITLE
Feat/#496 post view count

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/common/entity/Post.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/entity/Post.java
@@ -1,6 +1,7 @@
 package com.jeju.nanaland.domain.common.entity;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -27,6 +28,9 @@ public abstract class Post extends BaseEntity {
 
   @NotNull
   private Long priority;
+
+  @Column(name = "view_count", nullable = false, columnDefinition = "int default 0")
+  private int viewCount;
 
   protected Post(ImageFile firstImageFile, Long priority) {
     this.firstImageFile = firstImageFile;

--- a/src/main/java/com/jeju/nanaland/domain/common/repository/PostRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/repository/PostRepository.java
@@ -1,0 +1,15 @@
+package com.jeju.nanaland.domain.common.repository;
+
+import com.jeju.nanaland.domain.common.entity.Post;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+  @Modifying
+  @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :postId")
+  void increaseViewCount(@Param("postId") Long postId);
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
@@ -15,7 +15,10 @@ public class PostViewCountService {
 
   @Transactional
   public void increaseViewCount(Long postId, Long memberId) {
-    String redisKey = "post_viewed_" + memberId + "_" + postId;
+
+    // 8083은 dev, 도메인은 prod로 프로필을 설정하는 것이 어떨까요?
+    String env = System.getProperty("spring.profiles.active");
+    String redisKey = env + "_post_viewed_" + memberId + "_" + postId;
 
     // 30분 -> 1800초
     long cacheDurationSeconds = 1800L;

--- a/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
@@ -1,0 +1,32 @@
+package com.jeju.nanaland.domain.common.service;
+
+import com.jeju.nanaland.domain.common.repository.PostRepository;
+import com.jeju.nanaland.global.util.RedisUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostViewCountService {
+
+  private final PostRepository postRepository;
+  private final RedisUtil redisUtil;
+
+  @Transactional
+  public void increaseViewCount(Long postId, Long memberId) {
+    String redisKey = "post_viewed_" + memberId + "_" + postId;
+
+    // 30분 -> 1800초
+    long cacheDurationSeconds = 1800L;
+
+    // 30분 이내에 조회한 기록이 없으면
+    if (redisUtil.getValue(redisKey) == null) {
+      // 조회수 증가
+      postRepository.increaseViewCount(postId);
+      // 레디스에 등록
+      redisUtil.setExpiringValue(redisKey, "viewed", cacheDurationSeconds);
+    }
+
+  }
+}

--- a/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
@@ -2,9 +2,9 @@ package com.jeju.nanaland.domain.common.service;
 
 import com.jeju.nanaland.domain.common.repository.PostRepository;
 import com.jeju.nanaland.global.util.RedisUtil;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
+++ b/src/main/java/com/jeju/nanaland/domain/common/service/PostViewCountService.java
@@ -16,9 +16,7 @@ public class PostViewCountService {
   @Transactional
   public void increaseViewCount(Long postId, Long memberId) {
 
-    // 8083은 dev, 도메인은 prod로 프로필을 설정하는 것이 어떨까요?
-    String env = System.getProperty("spring.profiles.active");
-    String redisKey = env + "_post_viewed_" + memberId + "_" + postId;
+    String redisKey = "post_viewed_" + memberId + "_" + postId;
 
     // 30분 -> 1800초
     long cacheDurationSeconds = 1800L;

--- a/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/repository/ExperienceRepositoryCustom.java
@@ -17,6 +17,8 @@ public interface ExperienceRepositoryCustom {
 
   ExperienceCompositeDto findCompositeDtoById(Long id, Language language);
 
+  ExperienceCompositeDto findCompositeDtoByIdWithPessimisticLock(Long id, Language language);
+
   Page<ExperienceCompositeDto> searchCompositeDtoByKeyword(String keyword, Language language,
       Pageable pageable);
 
@@ -25,6 +27,8 @@ public interface ExperienceRepositoryCustom {
       List<AddressTag> addressTags, Pageable pageable);
 
   Set<ExperienceTypeKeyword> getExperienceTypeKeywordSet(Long postId);
+
+  Set<ExperienceTypeKeyword> getExperienceTypeKeywordSetWithWithPessimisticLock(Long postId);
 
   List<SearchPostForReviewDto> findAllSearchPostForReviewDtoByLanguage(Language language);
 

--- a/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
@@ -11,6 +11,7 @@ import com.jeju.nanaland.domain.common.dto.PostPreviewDto;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.common.service.PostService;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.experience.dto.ExperienceCompositeDto;
 import com.jeju.nanaland.domain.experience.dto.ExperienceResponse.ExperienceDetailDto;
 import com.jeju.nanaland.domain.experience.dto.ExperienceResponse.ExperienceThumbnail;
@@ -35,6 +36,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +48,7 @@ public class ExperienceService implements PostService {
   private final ImageFileRepository imageFileRepository;
   private final SearchService searchService;
   private final ReviewRepository reviewRepository;
+  private final PostViewCountService postViewCountService;
 
   /**
    * Experience 객체 조회
@@ -110,12 +113,13 @@ public class ExperienceService implements PostService {
         .build();
   }
 
+  @Transactional
   // 이색체험 상세 정보 조회
   public ExperienceDetailDto getExperienceDetail(MemberInfoDto memberInfoDto, Long postId,
       boolean isSearch) {
 
     Language language = memberInfoDto.getLanguage();
-    ExperienceCompositeDto experienceCompositeDto = experienceRepository.findCompositeDtoById(
+    ExperienceCompositeDto experienceCompositeDto = experienceRepository.findCompositeDtoByIdWithPessimisticLock(
         postId, language);
 
     // 해당 id의 포스트가 없는 경우 404 에러
@@ -138,12 +142,14 @@ public class ExperienceService implements PostService {
     images.addAll(imageFileRepository.findPostImageFiles(postId));
 
     // 키워드
-    Set<ExperienceTypeKeyword> keywordSet = experienceRepository.getExperienceTypeKeywordSet(
+    Set<ExperienceTypeKeyword> keywordSet = experienceRepository.getExperienceTypeKeywordSetWithWithPessimisticLock(
         postId);
     List<String> keywords = keywordSet.stream()
         .map(experienceTypeKeyword ->
             experienceTypeKeyword.getValueByLocale(language)
         ).toList();
+
+    postViewCountService.increaseViewCount(postId, member.getId());
 
     return ExperienceDetailDto.builder()
         .id(experienceCompositeDto.getId())

--- a/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/jeju/nanaland/domain/experience/service/ExperienceService.java
@@ -113,8 +113,9 @@ public class ExperienceService implements PostService {
         .build();
   }
 
-  @Transactional
+
   // 이색체험 상세 정보 조회
+  @Transactional
   public ExperienceDetailDto getExperienceDetail(MemberInfoDto memberInfoDto, Long postId,
       boolean isSearch) {
 
@@ -149,6 +150,7 @@ public class ExperienceService implements PostService {
             experienceTypeKeyword.getValueByLocale(language)
         ).toList();
 
+    // 조회 수 증가
     postViewCountService.increaseViewCount(postId, member.getId());
 
     return ExperienceDetailDto.builder()

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryCustom.java
@@ -13,6 +13,8 @@ public interface FestivalRepositoryCustom {
 
   FestivalCompositeDto findCompositeDtoById(Long id, Language locale);
 
+  FestivalCompositeDto findCompositeDtoByIdWithPessimisticLock(Long id, Language locale);
+
   Page<FestivalCompositeDto> searchCompositeDtoByKeyword(String keyword, Language locale,
       Pageable pageable);
 

--- a/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/festival/repository/FestivalRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.jeju.nanaland.domain.festival.dto.QFestivalCompositeDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +57,37 @@ public class FestivalRepositoryImpl implements FestivalRepositoryCustom {
         .where(festival.id.eq(id).and(festivalTrans.language.eq(language))
             .and(festival.status.eq(Status.ACTIVE))
         )
+        .fetchOne();
+  }
+
+  @Override
+  public FestivalCompositeDto findCompositeDtoByIdWithPessimisticLock(Long id, Language language) {
+    return queryFactory
+        .select(new QFestivalCompositeDto(
+            festival.id,
+            imageFile.originUrl,
+            imageFile.thumbnailUrl,
+            festival.contact,
+            festival.homepage,
+            festivalTrans.language,
+            festivalTrans.title,
+            festivalTrans.content,
+            festivalTrans.address,
+            festivalTrans.addressTag,
+            festivalTrans.time,
+            festivalTrans.intro,
+            festivalTrans.fee,
+            festival.startDate,
+            festival.endDate,
+            festival.season
+        ))
+        .from(festival)
+        .leftJoin(festival.firstImageFile, imageFile)
+        .leftJoin(festival.festivalTrans, festivalTrans)
+        .where(festival.id.eq(id).and(festivalTrans.language.eq(language))
+            .and(festival.status.eq(Status.ACTIVE))
+        )
+        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
         .fetchOne();
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryCustom.java
@@ -13,6 +13,8 @@ public interface MarketRepositoryCustom {
 
   MarketCompositeDto findCompositeDtoById(Long id, Language locale);
 
+  MarketCompositeDto findCompositeDtoByIdWithPessimisticLock(Long id, Language locale);
+
   Page<MarketThumbnail> findMarketThumbnails(Language locale, List<AddressTag> addressTags,
       Pageable pageable);
 

--- a/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
+++ b/src/main/java/com/jeju/nanaland/domain/market/repository/MarketRepositoryImpl.java
@@ -17,6 +17,7 @@ import com.jeju.nanaland.domain.market.dto.QMarketResponse_MarketThumbnail;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,32 @@ public class MarketRepositoryImpl implements MarketRepositoryCustom {
         .leftJoin(market.firstImageFile, imageFile)
         .leftJoin(market.marketTrans, marketTrans)
         .where(market.id.eq(id).and(marketTrans.language.eq(language)))
+        .fetchOne();
+  }
+
+  @Override
+  public MarketCompositeDto findCompositeDtoByIdWithPessimisticLock(Long id, Language language) {
+    return queryFactory
+        .select(new QMarketCompositeDto(
+            market.id,
+            imageFile.originUrl,
+            imageFile.thumbnailUrl,
+            market.contact,
+            market.homepage,
+            marketTrans.language,
+            marketTrans.title,
+            marketTrans.content,
+            marketTrans.address,
+            marketTrans.addressTag,
+            marketTrans.time,
+            marketTrans.intro,
+            marketTrans.amenity
+        ))
+        .from(market)
+        .leftJoin(market.firstImageFile, imageFile)
+        .leftJoin(market.marketTrans, marketTrans)
+        .where(market.id.eq(id).and(marketTrans.language.eq(language)))
+        .setLockMode(LockModeType.PESSIMISTIC_WRITE)
         .fetchOne();
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepository.java
+++ b/src/main/java/com/jeju/nanaland/domain/nana/repository/NanaRepository.java
@@ -1,10 +1,20 @@
 package com.jeju.nanaland.domain.nana.repository;
 
 import com.jeju.nanaland.domain.nana.entity.Nana;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NanaRepository extends JpaRepository<Nana, Long>, NanaRepositoryCustom {
 
   Optional<Nana> findNanaById(Long id);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT n FROM Nana n WHERE n.id = :id")
+  Optional<Nana> findNanaByIdWithPessimisticLock(@Param("id") Long id);
+
+
 }

--- a/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/nature/repository/NatureRepositoryCustom.java
@@ -13,10 +13,13 @@ public interface NatureRepositoryCustom {
 
   NatureCompositeDto findNatureCompositeDto(Long id, Language locale);
 
+  NatureCompositeDto findNatureCompositeDtoWithPessimisticLock(Long id, Language locale);
+
   Page<NatureCompositeDto> searchCompositeDtoByKeyword(String keyword, Language locale,
       Pageable pageable);
 
-  Page<PreviewDto> findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(Language locale, List<AddressTag> addressTags,
+  Page<PreviewDto> findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(Language locale,
+      List<AddressTag> addressTags,
       String keyword, Pageable pageable);
 
   PostPreviewDto findPostPreviewDto(Long postId, Language language);

--- a/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryCustom.java
+++ b/src/main/java/com/jeju/nanaland/domain/restaurant/repository/RestaurantRepositoryCustom.java
@@ -20,9 +20,15 @@ public interface RestaurantRepositoryCustom {
 
   RestaurantCompositeDto findCompositeDtoById(Long postId, Language language);
 
+  RestaurantCompositeDto findCompositeDtoByIdWithPessimisticLock(Long postId, Language language);
+
   Set<RestaurantTypeKeyword> getRestaurantTypeKeywordSet(Long postId);
 
+  Set<RestaurantTypeKeyword> getRestaurantTypeKeywordSetWithPessimisticLock(Long postId);
+
   List<RestaurantMenuDto> getRestaurantMenuList(Long postId, Language language);
+
+  List<RestaurantMenuDto> getRestaurantMenuListWithPessimisticLock(Long postId, Language language);
 
   Page<RestaurantCompositeDto> searchCompositeDtoByKeyword(String keyword, Language language,
       Pageable pageable);

--- a/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/experience/service/ExperienceServiceTest.java
@@ -13,6 +13,7 @@ import com.jeju.nanaland.domain.common.dto.PostPreviewDto;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.experience.dto.ExperienceCompositeDto;
 import com.jeju.nanaland.domain.experience.dto.ExperienceResponse.ExperienceDetailDto;
 import com.jeju.nanaland.domain.experience.dto.ExperienceResponse.ExperienceThumbnail;
@@ -59,6 +60,8 @@ class ExperienceServiceTest {
   ImageFileRepository imageFileRepository;
   @Mock
   ReviewRepository reviewRepository;
+  @Mock
+  private PostViewCountService postViewCountService;
 
   @Test
   @DisplayName("이색체험 preview 정보 조회")
@@ -119,7 +122,7 @@ class ExperienceServiceTest {
         .build();
 
     doReturn(experienceCompositeDto).when(experienceRepository)
-        .findCompositeDtoById(postId, language);
+        .findCompositeDtoByIdWithPessimisticLock(postId, language);
     doReturn(false).when(memberFavoriteService)
         .isPostInFavorite(memberInfoDto.getMember(), Category.EXPERIENCE, postId);
     doReturn(List.of()).when(imageFileRepository)  // 빈 이미지 리스트

--- a/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/festival/service/FestivalServiceTest.java
@@ -16,6 +16,7 @@ import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.favorite.service.MemberFavoriteService;
 import com.jeju.nanaland.domain.festival.dto.FestivalCompositeDto;
 import com.jeju.nanaland.domain.festival.dto.FestivalResponse.FestivalDetailDto;
@@ -50,6 +51,8 @@ class FestivalServiceTest {
   private MemberFavoriteService memberFavoriteService;
   @Mock
   private ImageFileService imageFileService;
+  @Mock
+  private PostViewCountService postViewCountService;
 
 
   @Mock
@@ -123,9 +126,9 @@ class FestivalServiceTest {
     FestivalCompositeDto msFestivalCompositeDto = createFestivalCompositeDto(Language.MALAYSIA,
         startDate, endDate);
 
-    when(festivalRepository.findCompositeDtoById(1L,
+    when(festivalRepository.findCompositeDtoByIdWithPessimisticLock(1L,
         krMemberInfoDto.getLanguage())).thenReturn(krFestivalCompositeDto);
-    when(festivalRepository.findCompositeDtoById(1L,
+    when(festivalRepository.findCompositeDtoByIdWithPessimisticLock(1L,
         msMemberInfoDto.getLanguage())).thenReturn(msFestivalCompositeDto);
     when(memberFavoriteService.isPostInFavorite(any(), eq(FESTIVAL), anyLong()))
         .thenReturn(false);

--- a/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/market/service/MarketServiceTest.java
@@ -16,6 +16,7 @@ import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.favorite.service.MemberFavoriteService;
 import com.jeju.nanaland.domain.market.dto.MarketCompositeDto;
 import com.jeju.nanaland.domain.market.dto.MarketResponse.MarketDetailDto;
@@ -60,6 +61,8 @@ class MarketServiceTest {
   ImageFileRepository imageFileRepository;
   @Mock
   private ImageFileService imageFileService;
+  @Mock
+  private PostViewCountService postViewCountService;
 
   @Test
   @DisplayName("전통시장 preview 정보 조회")
@@ -144,7 +147,7 @@ class MarketServiceTest {
     );
 
     doReturn(marketDetailDto).when(marketRepository)
-        .findCompositeDtoById(any(Long.class), eq(locale));
+        .findCompositeDtoByIdWithPessimisticLock(any(Long.class), eq(locale));
     doReturn(false).when(memberFavoriteService)
         .isPostInFavorite(any(Member.class), any(Category.class), any(Long.class));
     doReturn(images).when(imageFileService)

--- a/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nana/service/NanaServiceTest.java
@@ -13,6 +13,7 @@ import com.jeju.nanaland.domain.common.dto.PostPreviewDto;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.favorite.service.MemberFavoriteService;
 import com.jeju.nanaland.domain.hashtag.repository.HashtagRepository;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
@@ -62,6 +63,8 @@ public class NanaServiceTest {
   private HashtagRepository hashtagRepository;
   @Mock
   private ImageFileRepository imageFileRepository;
+  @Mock
+  private PostViewCountService postViewCountService;
   @InjectMocks
   private NanaService nanaService;
 
@@ -177,7 +180,7 @@ public class NanaServiceTest {
     List<List<ImageFileDto>> nanaContentImages = createNanaContentImage();
     Category category = Category.NANA;
 
-    when(nanaRepository.findNanaById(anyLong())).thenReturn(Optional.of(nana));
+    when(nanaRepository.findNanaByIdWithPessimisticLock(anyLong())).thenReturn(Optional.of(nana));
     when(nanaTitleRepository.findNanaTitleByNanaAndLanguage(nana, language)).thenReturn(
         Optional.of(nanaTitle));
     when(nanaContentRepository.findAllByNanaTitleOrderByPriority(nanaTitle)).thenReturn(

--- a/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/nature/service/NatureServiceTest.java
@@ -18,6 +18,7 @@ import com.jeju.nanaland.domain.common.dto.PostPreviewDto;
 import com.jeju.nanaland.domain.common.entity.ImageFile;
 import com.jeju.nanaland.domain.common.entity.Post;
 import com.jeju.nanaland.domain.common.service.ImageFileService;
+import com.jeju.nanaland.domain.common.service.PostViewCountService;
 import com.jeju.nanaland.domain.favorite.service.MemberFavoriteService;
 import com.jeju.nanaland.domain.member.dto.MemberResponse.MemberInfoDto;
 import com.jeju.nanaland.domain.member.entity.Member;
@@ -63,6 +64,8 @@ class NatureServiceTest {
   private SearchService searchService;
   @Mock
   private ImageFileService imageFileService;
+  @Mock
+  private PostViewCountService postViewCountService;
 
   @BeforeEach
   void setUp() {
@@ -174,6 +177,7 @@ class NatureServiceTest {
   @Nested
   @DisplayName("7대 자연 프리뷰 페이징 조회 TEST")
   class GetNaturePreview {
+
     @Test
     @DisplayName("성공 - 기본 케이스")
     void getNaturePreviewSuccess() {
@@ -183,7 +187,8 @@ class NatureServiceTest {
       Page<NatureResponse.PreviewDto> naturePreviewDtos = createNaturePreviews(pageSize, totalSize);
 
       doReturn(naturePreviewDtos).when(natureRepository)
-          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(), any(), any());
+          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(),
+              any(), any());
       doReturn(new ArrayList<>()).when(memberFavoriteService)
           .getFavoritePostIdsWithMember(any(Member.class));
 
@@ -212,7 +217,8 @@ class NatureServiceTest {
           PageRequest.of(pageNumber, pageSize), 0);
 
       doReturn(naturePreviewDtos).when(natureRepository)
-          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(), any(), any());
+          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(),
+              any(), any());
       doReturn(new ArrayList<>()).when(memberFavoriteService)
           .getFavoritePostIdsWithMember(any(Member.class));
 
@@ -235,7 +241,8 @@ class NatureServiceTest {
       List<Long> favoriteIds = List.of(1L);
 
       doReturn(naturePreviewDtos).when(natureRepository)
-          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(), any(), any());
+          .findAllNaturePreviewDtoOrderByPriorityAndCreatedAtDesc(any(Language.class), anyList(),
+              any(), any());
       doReturn(favoriteIds).when(memberFavoriteService)
           .getFavoritePostIdsWithMember(any(Member.class));
 
@@ -254,11 +261,12 @@ class NatureServiceTest {
   @Nested
   @DisplayName("7대 자연 상세 조회 TEST")
   class GetNatureDetail {
+
     @Test
     @DisplayName("실패 - 해당 게시물이 존재하지 않는 경우")
     void getNatureDetailFail_postNotFound() {
       // given: 7대 자연 게시물이 존재하지 않도록 설정
-      doReturn(null).when(natureRepository).findNatureCompositeDto(any(), any());
+      doReturn(null).when(natureRepository).findNatureCompositeDtoWithPessimisticLock(any(), any());
 
       // when: 7대 자연 상세 조회
       // then: ErrorCode 검증
@@ -278,13 +286,15 @@ class NatureServiceTest {
           new ImageFileDto("origin url 2", "thumbnail url 2")
       );
 
-      doReturn(natureCompositeDto).when(natureRepository).findNatureCompositeDto(any(), any());
+      doReturn(natureCompositeDto).when(natureRepository)
+          .findNatureCompositeDtoWithPessimisticLock(any(), any());
       doReturn(true).when(memberFavoriteService).isPostInFavorite(any(), any(), any());
       doReturn(images).when(imageFileService)
           .getPostImageFilesByPostIdIncludeFirstImage(1L, natureCompositeDto.getFirstImage());
 
       // when: 7대 자연 상세 조회 (검색이용)
-      NatureResponse.DetailDto natureDetail = natureService.getNatureDetail(memberInfoDto, 1L, true);
+      NatureResponse.DetailDto natureDetail = natureService.getNatureDetail(memberInfoDto, 1L,
+          true);
 
       // then: 7대 자연 상세 정보 검증
       assertThat(natureDetail.getTitle()).isEqualTo(natureCompositeDto.getTitle());


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- 조회 시 다른 동작을 추가할 때 동시성이 발생하는 이유 -> 조회를 통한 s-lock 이후 x-lock을 추가하려 할 때 deadlock 발생
- 해결책 -> 조회부터 x-lock을 선점해버린다.
<img src="https://github.com/user-attachments/assets/037d65ab-0295-4204-b6a3-093104707fee" width="500" height="auto">


- 동시성 문제에서 지금 사용한 비관적 락 방법이 가장 많은 해결책으로 나옴.
- 우리 서비스에서는 전혀 문제가 없을 예정이지만 트래픽이 준수한 서비스에서는 redis를 활용한 방법이 더 나아 보여서 사용하려 했는데 저희가 조회수가 지금 필요한 이유가 기획 측에서 필요하다 한건데 이걸 redis에 저장하면 보여줄 때 답이 없을 것 같아서 데이터 베이스 컬럼에 바로 저장되는 방법을 사용했습니다..

<img width="667" alt="image" src="https://github.com/user-attachments/assets/d4fca036-1a6d-4e4e-8f0d-06a089150332">

- pr을 올려놓고 생각해보니 저희 dev, prod가 같은 redis를 사용하는 것 같아서, 지금은 두개의 서버가 모두 prod 프로필로 실행되는데 8083을 dev로 프로필을 바꾸면 어떨까요??? (redis를 분리하는 방법도 고려해보는게 좋을까요 여러분의 의견을 받습니다)
<br>

## 💬 To Reviewers
- [ ]

<br>

## ☑️ Related Issue
> 관련 이슈
