### PR TITLE
[Feat] 회원 프로필 수정 API에서 MultipartFile 제거

### DIFF
--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -305,7 +305,7 @@ public class MemberController {
   })
   @GetMapping("/randomProfile")
   public BaseResponse<String> getRandomProfileImageUrl() {
-    String randomProfileImageUrl = memberProfileService.getRandomProfileImageUrl();
+    String randomProfileImageUrl = memberProfileService.getRandomImageFile().getOriginUrl();
     return BaseResponse.success(RANDOM_URL_SUCCESS, randomProfileImageUrl);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -201,16 +201,12 @@ public class MemberController {
       @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "이미지 업로드에 실패한 경우", content = @Content)
   })
-  @PatchMapping(
-      value = "/profile",
-      consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PatchMapping(value = "/profile")
   public BaseResponse<String> updateProfile(
       @AuthMember MemberInfoDto memberInfoDto,
-      @RequestPart @Valid MemberRequest.ProfileUpdateDto reqDto,
-      @RequestPart(required = false) MultipartFile multipartFile,
-      @RequestParam(defaultValue = "false") boolean isImageDelete) {
-
-    memberProfileService.updateProfile(memberInfoDto, reqDto, multipartFile, isImageDelete);
+      @RequestBody @Valid MemberRequest.ProfileUpdateDto reqDto,
+      @RequestParam(required = false) String fileKey) {
+    memberProfileService.updateProfile(memberInfoDto, reqDto, fileKey);
     return BaseResponse.success(UPDATE_MEMBER_PROFILE_SUCCESS);
   }
 

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -4,7 +4,6 @@ import static com.jeju.nanaland.global.exception.SuccessCode.GET_MEMBER_PROFILE_
 import static com.jeju.nanaland.global.exception.SuccessCode.GET_RECOMMENDED_POSTS_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.JOIN_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.LOGIN_SUCCESS;
-import static com.jeju.nanaland.global.exception.SuccessCode.RANDOM_URL_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.REISSUE_TOKEN_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_LANGUAGE_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_CONSENT_SUCCESS;
@@ -295,17 +294,5 @@ public class MemberController {
       memberProfileService.validateNickname(nickname, memberId);
     }
     return BaseResponse.success(VALID_NICKNAME_SUCCESS);
-  }
-
-  @Operation(
-      summary = "랜덤 프로필 url 조회", description = "랜덤 프로필 url이 응답됩니다.")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
-  })
-  @GetMapping("/randomProfile")
-  public BaseResponse<String> getRandomProfileImageUrl() {
-    String randomProfileImageUrl = memberProfileService.getRandomImageFile().getOriginUrl();
-    return BaseResponse.success(RANDOM_URL_SUCCESS, randomProfileImageUrl);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import static com.jeju.nanaland.global.exception.SuccessCode.GET_MEMBER_PROFILE_
 import static com.jeju.nanaland.global.exception.SuccessCode.GET_RECOMMENDED_POSTS_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.JOIN_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.LOGIN_SUCCESS;
+import static com.jeju.nanaland.global.exception.SuccessCode.RANDOM_URL_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.REISSUE_TOKEN_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_LANGUAGE_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.UPDATE_MEMBER_CONSENT_SUCCESS;
@@ -298,5 +299,17 @@ public class MemberController {
       memberProfileService.validateNickname(nickname, memberId);
     }
     return BaseResponse.success(VALID_NICKNAME_SUCCESS);
+  }
+
+  @Operation(
+      summary = "랜덤 프로필 url 조회", description = "랜덤 프로필 url이 응답됩니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "401", description = "accessToken이 유효하지 않은 경우", content = @Content),
+  })
+  @GetMapping("/randomProfile")
+  public BaseResponse<String> getRandomProfileImageUrl() {
+    String randomProfileImageUrl = memberProfileService.getRandomProfileImageUrl();
+    return BaseResponse.success(RANDOM_URL_SUCCESS, randomProfileImageUrl);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
@@ -78,6 +78,8 @@ public class MemberResponse {
     List<ConsentItemDto> consentItems;
     @Schema(description = "내 프로필인지 확인 여부")
     private boolean isMyProfile;
+    @Schema(description = "기본 프로필인지 확인 여부")
+    private boolean isDefault;
     @Schema(description = "유저 Id")
     private Long memberId;
     @Schema(description = "이메일")

--- a/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/dto/MemberResponse.java
@@ -78,8 +78,6 @@ public class MemberResponse {
     List<ConsentItemDto> consentItems;
     @Schema(description = "내 프로필인지 확인 여부")
     private boolean isMyProfile;
-    @Schema(description = "기본 프로필인지 확인 여부")
-    private boolean isDefault;
     @Schema(description = "유저 Id")
     private Long memberId;
     @Schema(description = "이메일")

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberLoginService.java
@@ -50,7 +50,7 @@ public class MemberLoginService {
   private final ImageFileService imageFileService;
   private final FcmTokenService fcmTokenService;
   private final FileService fileService;
-  private final ProfileImageService profileImageService;
+  private final MemberProfileService memberProfileService;
 
   /**
    * 회원 가입
@@ -73,7 +73,7 @@ public class MemberLoginService {
 
     String nickname = determineNickname(joinDto);
     validateNickname(nickname);
-    ImageFile profileImageFile = profileImageService.saveRandomProfileImageFile();
+    ImageFile profileImageFile = memberProfileService.saveRandomProfileImageFile();
     Member member = createMember(joinDto, profileImageFile, nickname);
 
     // GUEST가 아닌 경우, 이용약관 저장

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -117,12 +117,8 @@ public class MemberProfileService {
           ).toList();
     }
 
-    boolean isDefault = defaultProfile.stream()
-        .anyMatch(member.getProfileImageFile().getOriginUrl()::contains);
-
     return MemberResponse.ProfileDto.builder()
         .isMyProfile(isMyProfile)
-        .isDefault(isDefault)
         .consentItems(consentItems)
         .memberId(member.getId())
         .email(member.getEmail())

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -87,6 +87,8 @@ public class MemberProfileService {
     Language language = member.getLanguage();
 
     boolean isMyProfile = memberId == null || member.getId().equals(memberId);
+    boolean isDefault = profileImageService.isDefaultProfileImage(
+        member.getProfileImageFile().getOriginUrl());
     if (!isMyProfile) {
       member = memberRepository.findById(memberId)
           .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
@@ -114,6 +116,7 @@ public class MemberProfileService {
 
     return MemberResponse.ProfileDto.builder()
         .isMyProfile(isMyProfile)
+        .isDefault(isDefault)
         .consentItems(consentItems)
         .memberId(member.getId())
         .email(member.getEmail())

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -15,6 +15,7 @@ import com.jeju.nanaland.global.exception.ConflictException;
 import com.jeju.nanaland.global.exception.ErrorCode;
 import com.jeju.nanaland.global.exception.NotFoundException;
 import com.jeju.nanaland.global.exception.ServerErrorException;
+import com.jeju.nanaland.global.image_upload.dto.S3ImageDto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -157,5 +158,10 @@ public class MemberProfileService {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND.getMessage()));
     validateNickname(nickname, member);
+  }
+
+  public String getRandomProfileImageUrl() {
+    S3ImageDto s3ImageDto = profileImageService.getRandomImageFile();
+    return s3ImageDto.getOriginUrl();
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/MemberProfileService.java
@@ -54,7 +54,7 @@ public class MemberProfileService {
     Member member = memberInfoDto.getMember();
     validateNickname(profileUpdateDto.getNickname(), member);
     if (fileKey != null) {
-      S3ImageDto s3ImageDto = fileUploadService.getS3ImageUrls(fileKey);
+      S3ImageDto s3ImageDto = fileUploadService.getCloudImageUrls(fileKey);
       member.getProfileImageFile().updateImageFile(s3ImageDto.getOriginUrl(), s3ImageDto.getThumbnailUrl());
     }
     member.updateProfile(profileUpdateDto);
@@ -176,6 +176,6 @@ public class MemberProfileService {
 
   public S3ImageDto getRandomImageFile() {
     String selectedProfile = defaultProfile.get(random.nextInt(defaultProfile.size()));
-    return fileUploadService.getS3ImageUrls(selectedProfile);
+    return fileUploadService.getCloudImageUrls(selectedProfile);
   }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/ProfileImageService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/ProfileImageService.java
@@ -97,4 +97,9 @@ public class ProfileImageService {
     ImageFile originImageFile = member.getProfileImageFile();
     originImageFile.updateImageFile(s3ImageDto.getOriginUrl(), s3ImageDto.getThumbnailUrl());
   }
+
+  public boolean isDefaultProfileImage(String originUrl) {
+    return defaultProfile.stream()
+        .anyMatch(originUrl::contains);
+  }
 }

--- a/src/main/java/com/jeju/nanaland/domain/member/service/ProfileImageService.java
+++ b/src/main/java/com/jeju/nanaland/domain/member/service/ProfileImageService.java
@@ -1,27 +1,16 @@
 package com.jeju.nanaland.domain.member.service;
 
 import static com.jeju.nanaland.global.exception.ErrorCode.MEMBER_NOT_FOUND;
-import static com.jeju.nanaland.global.exception.ErrorCode.SERVER_ERROR;
 
 import com.jeju.nanaland.domain.common.entity.ImageFile;
-import com.jeju.nanaland.domain.common.repository.ImageFileRepository;
 import com.jeju.nanaland.domain.member.entity.Member;
 import com.jeju.nanaland.domain.member.repository.MemberRepository;
 import com.jeju.nanaland.global.exception.NotFoundException;
-import com.jeju.nanaland.global.exception.ServerErrorException;
-import com.jeju.nanaland.global.image_upload.S3ImageService;
 import com.jeju.nanaland.global.image_upload.dto.S3ImageDto;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -29,66 +18,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileImageService {
 
   private final MemberRepository memberRepository;
-  @Value("${cloud.aws.s3.memberProfileDirectory}")
-  private String MEMBER_PROFILE_DIRECTORY;
-  private final S3ImageService s3ImageService;
-  private final ImageFileRepository imageFileRepository;
-
-  private final List<String> defaultProfile = Arrays.asList("LightPurple.png", "LightGray.png",
-      "Gray.png", "DeepBlue.png");
-  private final Random random = new Random();
-
-  public ImageFile saveRandomProfileImageFile() {
-    S3ImageDto s3ImageDto = getRandomImageFile();
-    return saveS3ImageFile(s3ImageDto);
-  }
-
-  public S3ImageDto getRandomImageFile() {
-    String selectedProfile = defaultProfile.get(random.nextInt(defaultProfile.size()));
-    return s3ImageService.getS3Urls(selectedProfile, MEMBER_PROFILE_DIRECTORY);
-  }
-
-  public ImageFile saveS3ImageFile(S3ImageDto s3ImageDto) {
-    ImageFile imageFile = ImageFile.builder()
-        .originUrl(s3ImageDto.getOriginUrl())
-        .thumbnailUrl(s3ImageDto.getThumbnailUrl())
-        .build();
-    return imageFileRepository.save(imageFile);
-  }
-
-  @Transactional
-  public void setRandomProfileImage(Member member) {
-    S3ImageDto s3ImageDto = getRandomImageFile();
-    ImageFile profileImageFile = member.getProfileImageFile();
-    profileImageFile.updateImageFile(s3ImageDto.getOriginUrl(), s3ImageDto.getThumbnailUrl());
-  }
-
-  /**
-   * 프로필 사진 업데이트
-   *
-   * @param multipartFile 프로필 사진
-   * @param member        회원
-   */
-  @Transactional
-  public  void updateProfileImage(MultipartFile multipartFile, Member member) {
-    ImageFile profileImageFile = member.getProfileImageFile();
-    try {
-      CompletableFuture<S3ImageDto> futureS3ImageDto = s3ImageService.uploadImageToS3(multipartFile,
-          true, MEMBER_PROFILE_DIRECTORY);
-      S3ImageDto s3ImageDto = futureS3ImageDto.get();
-      if (!s3ImageService.isDefaultProfileImage(profileImageFile)) {
-        s3ImageService.deleteImageS3(profileImageFile, MEMBER_PROFILE_DIRECTORY);
-      }
-      profileImageFile.updateImageFile(s3ImageDto.getOriginUrl(), s3ImageDto.getThumbnailUrl());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      log.error("스레드 중단", e);
-      throw new ServerErrorException(SERVER_ERROR.getMessage());
-    } catch (ExecutionException e) {
-      log.error("비동기 작업 실행 중 발생하는 예외 발생", e);
-      throw new ServerErrorException(SERVER_ERROR.getMessage());
-    }
-  }
 
   @Transactional
   public void updateMemberProfileImage(Long memberId, S3ImageDto s3ImageDto) {
@@ -96,10 +25,5 @@ public class ProfileImageService {
         .orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND.getMessage()));
     ImageFile originImageFile = member.getProfileImageFile();
     originImageFile.updateImageFile(s3ImageDto.getOriginUrl(), s3ImageDto.getThumbnailUrl());
-  }
-
-  public boolean isDefaultProfileImage(String originUrl) {
-    return defaultProfile.stream()
-        .anyMatch(originUrl::contains);
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/config/S3Config.java
+++ b/src/main/java/com/jeju/nanaland/global/config/S3Config.java
@@ -1,15 +1,13 @@
-package com.jeju.nanaland.global.image_upload;
+package com.jeju.nanaland.global.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Slf4j
 @Configuration
 public class S3Config {
 

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -32,6 +32,9 @@ public enum ErrorCode {
   SELF_REPORT_NOT_ALLOWED(BAD_REQUEST, "본인을 신고하는 요청은 유효하지 않습니다."),
   ALREADY_REPORTED(BAD_REQUEST, "이미 신고되었습니다."),
   NO_NOTIFICATION_CONSENT(BAD_REQUEST, "알림 동의를 하지 않은 유저입니다."),
+  INVALID_FILE_SIZE(BAD_REQUEST, "파일 크기가 유효하지 않습니다."),
+  INVALID_FILE_EXTENSION_TYPE(BAD_REQUEST, "해당 카테고리에서 지원하지 않는 파일 형식입니다."),
+  NO_FILE_EXTENSION(BAD_REQUEST, "파일 확장자가 없습니다."),
 
   //INTERNAL_SERVER_ERROR
   SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버측 에러입니다."),

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
   EXTRACT_NAME_ERROR(INTERNAL_SERVER_ERROR, "이미지 파일 이름 추출 에러"),
   MAIL_FAIL_ERROR(INTERNAL_SERVER_ERROR, "메일 전송 실패"),
   FILE_FAIL_ERROR(INTERNAL_SERVER_ERROR, "파일 변환 중 오류가 발생했습니다."),
+  FILE_UPLOAD_FAIL(INTERNAL_SERVER_ERROR, "파일 업로드 실패"),
 
   //UNAUTHORIZED
   UNAUTHORIZED_USER(UNAUTHORIZED, "access token이 존재하지 않습니다."),

--- a/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
   KEYWORD_NOT_FOUND(NOT_FOUND, "존재하지 않는 키워드 입니다."),
   INFO_TYPE_NOT_FOUND(NOT_FOUND, "존재하지 않는 InfoType 입니다."),
   LANGUAGE_NOT_FOUND(NOT_FOUND, "지원하지 않는 언어입니다."),
+  FILE_S3_NOT_FOUNE(NOT_FOUND, "파일을 S3에서 찾을 수 없습니다."),
 
   // CONFLICT
   CONFLICT_DATA(CONFLICT, "이미 존재하는 데이터입니다."),

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -82,7 +82,10 @@ public enum SuccessCode {
 
   // notification
   NOTIFICATION_LIST_SUCCESS(OK, "알림 조회 성공"),
-  SEND_NOTIFICATION_SUCCESS(CREATED, "알림 전송 성공");
+  SEND_NOTIFICATION_SUCCESS(CREATED, "알림 전송 성공"),
+
+  // file
+  GET_PRESIGNED_URL_SUCCESS(OK, "Pre-Signed URL 발급 성공");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -85,7 +85,8 @@ public enum SuccessCode {
   SEND_NOTIFICATION_SUCCESS(CREATED, "알림 전송 성공"),
 
   // file
-  GET_PRESIGNED_URL_SUCCESS(OK, "Pre-Signed URL 발급 성공");
+  GET_PRESIGNED_URL_SUCCESS(OK, "Pre-Signed URL 발급 성공"),
+  COMPLETE_PRESIGNED_URL_SUCCESS(OK, "Pre-Signed URL 업로드 완료 성공");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -19,6 +19,7 @@ public enum SuccessCode {
   UPDATE_MEMBER_PROFILE_SUCCESS(OK, "사용자 프로필 수정 성공"),
   GET_MEMBER_PROFILE_SUCCESS(OK, "사용자 프로필 조회 성공"),
   UPDATE_LANGUAGE_SUCCESS(OK, "언어 변경 성공"),
+  RANDOM_URL_SUCCESS(OK, "랜덤 기본 프로필 URL 조회 성공"),
 
   // search
   SEARCH_SUCCESS(OK, "검색에 성공했습니다."),

--- a/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
+++ b/src/main/java/com/jeju/nanaland/global/exception/SuccessCode.java
@@ -19,7 +19,6 @@ public enum SuccessCode {
   UPDATE_MEMBER_PROFILE_SUCCESS(OK, "사용자 프로필 수정 성공"),
   GET_MEMBER_PROFILE_SUCCESS(OK, "사용자 프로필 조회 성공"),
   UPDATE_LANGUAGE_SUCCESS(OK, "언어 변경 성공"),
-  RANDOM_URL_SUCCESS(OK, "랜덤 기본 프로필 URL 조회 성공"),
 
   // search
   SEARCH_SUCCESS(OK, "검색에 성공했습니다."),

--- a/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
+++ b/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
@@ -7,6 +7,10 @@ import com.jeju.nanaland.global.BaseResponse;
 import com.jeju.nanaland.global.file.dto.FileRequest;
 import com.jeju.nanaland.global.file.dto.FileResponse;
 import com.jeju.nanaland.global.file.service.FileUploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,11 @@ public class FileUploadController {
 
   private final FileUploadService fileUploadService;
 
+  @Operation(summary = "Pre-Signed URL 업로드 시작 API")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
   @PostMapping("/upload-init")
   public BaseResponse<FileResponse.InitResultDto> uploadInit(
       @RequestBody @Valid FileRequest.InitCommandDto initCommandDto
@@ -33,6 +42,11 @@ public class FileUploadController {
     return BaseResponse.success(GET_PRESIGNED_URL_SUCCESS, initResultDto);
   }
 
+  @Operation(summary = "Pre-Signed URL 업로드 완료 API")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
+  })
   @PostMapping("/upload-complete")
   public BaseResponse<Void> uploadComplete(
       @RequestBody @Valid FileRequest.CompleteCommandDto completeCommandDto

--- a/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
+++ b/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package com.jeju.nanaland.global.file.controller;
 
+import static com.jeju.nanaland.global.exception.SuccessCode.COMPLETE_PRESIGNED_URL_SUCCESS;
 import static com.jeju.nanaland.global.exception.SuccessCode.GET_PRESIGNED_URL_SUCCESS;
 
 import com.jeju.nanaland.global.BaseResponse;
@@ -30,5 +31,13 @@ public class FileUploadController {
   ){
     FileResponse.InitResultDto initResultDto = fileUploadService.uploadInit(initCommandDto);
     return BaseResponse.success(GET_PRESIGNED_URL_SUCCESS, initResultDto);
+  }
+
+  @PostMapping("/upload-complete")
+  public BaseResponse<Void> uploadComplete(
+      @RequestBody @Valid FileRequest.CompleteCommandDto completeCommandDto
+  ) {
+    fileUploadService.uploadComplete(completeCommandDto);
+    return BaseResponse.success(COMPLETE_PRESIGNED_URL_SUCCESS);
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
+++ b/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
@@ -32,6 +32,7 @@ public class FileUploadController {
   @Operation(summary = "Pre-Signed URL 업로드 시작 API")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "올바르지 않은 요청인 경우", content = @Content),
       @ApiResponse(responseCode = "500", description = "서버측 에러", content = @Content)
   })
   @PostMapping("/upload-init")

--- a/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
+++ b/src/main/java/com/jeju/nanaland/global/file/controller/FileUploadController.java
@@ -1,0 +1,34 @@
+package com.jeju.nanaland.global.file.controller;
+
+import static com.jeju.nanaland.global.exception.SuccessCode.GET_PRESIGNED_URL_SUCCESS;
+
+import com.jeju.nanaland.global.BaseResponse;
+import com.jeju.nanaland.global.file.dto.FileRequest;
+import com.jeju.nanaland.global.file.dto.FileResponse;
+import com.jeju.nanaland.global.file.service.FileUploadService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/file")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "파일(File)", description = "파일(File) API입니다.")
+public class FileUploadController {
+
+  private final FileUploadService fileUploadService;
+
+  @PostMapping("/upload-init")
+  public BaseResponse<FileResponse.InitResultDto> uploadInit(
+      @RequestBody @Valid FileRequest.InitCommandDto initCommandDto
+  ){
+    FileResponse.InitResultDto initResultDto = fileUploadService.uploadInit(initCommandDto);
+    return BaseResponse.success(GET_PRESIGNED_URL_SUCCESS, initResultDto);
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/file/data/FileCategory.java
+++ b/src/main/java/com/jeju/nanaland/global/file/data/FileCategory.java
@@ -1,0 +1,20 @@
+package com.jeju.nanaland.global.file.data;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public enum FileCategory {
+
+  MEMBER_PROFILE(Arrays.asList("jpeg", "jpg", "png", "webp")),
+  REVIEW(Arrays.asList("jpeg", "jpg", "png", "webp")),
+  INFO_FIX_REPORT(Arrays.asList("jpeg", "jpg", "png", "webp")),
+  CLAIM_REPORT(Arrays.asList("jpeg", "jpg", "png", "webp", "mp4", "mov", "webm"));
+
+  private final List<String> allowedExtensions;
+
+  FileCategory(List<String> allowedExtensions) {
+    this.allowedExtensions = allowedExtensions;
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
@@ -4,7 +4,9 @@ import com.jeju.nanaland.domain.common.annotation.EnumValid;
 import com.jeju.nanaland.global.file.data.FileCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 
@@ -33,5 +35,30 @@ public class FileRequest {
         allowableValues = {"MEMBER_PROFILE", "REVIEW", "INFO_FIX_REPORT", "CLAIM_REPORT"}
     )
     private String fileCategory;
+  }
+
+  @Schema(description = "파일 업로드 완료 요청 Dto")
+  @Data
+  @Builder
+  public static class CompleteCommandDto {
+
+    @NotBlank
+    @Schema(description = "UPLOAD ID")
+    private String uploadId;
+
+    @NotBlank
+    @Schema(description = "파일 키")
+    private String fileKey;
+
+    @NotEmpty
+    @Schema(description = "파트 정보 리스트")
+    private List<PartInfo> parts;
+  }
+
+  @Data
+  @Builder
+  public static class PartInfo {
+    private int partNumber;
+    private String eTag;
   }
 }

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
@@ -1,0 +1,37 @@
+package com.jeju.nanaland.global.file.dto;
+
+import com.jeju.nanaland.domain.common.annotation.EnumValid;
+import com.jeju.nanaland.global.file.data.FileCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+public class FileRequest {
+
+  @Schema(description = "파일 업로드 시작 요청 Dto")
+  @Data
+  @Builder
+  public static class InitCommandDto {
+
+    @NotBlank
+    @Schema(description = "원본 파일명 (확장자 포함)")
+    private String originalFileName;
+
+    @NotNull
+    @Schema(description = "파일 크기")
+    private Long fileSize;
+
+    @EnumValid(
+        enumClass = FileCategory.class,
+        message = "해당 파일 카테고리가 존재하지 않습니다."
+    )
+    @Schema(
+        description = "파일 카테고리",
+        example = "MEMBER_PROFILE",
+        allowableValues = {"MEMBER_PROFILE", "REVIEW", "INFO_FIX_REPORT", "CLAIM_REPORT"}
+    )
+    private String fileCategory;
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
@@ -25,6 +25,10 @@ public class FileRequest {
     @Schema(description = "파일 크기")
     private Long fileSize;
 
+    @NotNull
+    @Schema(description = "파일 파트 개수")
+    private int partCount;
+
     @EnumValid(
         enumClass = FileCategory.class,
         message = "해당 파일 카테고리가 존재하지 않습니다."

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileRequest.java
@@ -18,7 +18,7 @@ public class FileRequest {
   public static class InitCommandDto {
 
     @NotBlank
-    @Schema(description = "원본 파일명 (확장자 포함)")
+    @Schema(description = "원본 파일명 (확장자 포함)", example = "해수욕장.jpg")
     private String originalFileName;
 
     @NotNull

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileResponse.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileResponse.java
@@ -11,7 +11,10 @@ public class FileResponse {
   @Builder
   @Schema(description = "파트별 Pre-Signed URL 정보")
   public static class InitResultDto {
-
+    @Schema(description = "UPLOAD ID")
+    private String uploadId;
+    @Schema(description = "파일 키")
+    private String fileKey;
     @Schema(description = "Pre-Signed URL 정보 리스트")
     List<PresignedUrlInfo> presignedUrlInfos;
   }
@@ -20,7 +23,6 @@ public class FileResponse {
   @Builder
   @Schema(description = "Pre-Signed URL 정보 리스트")
   public static class PresignedUrlInfo {
-
     private int partNumber;
     private String preSignedUrl;
   }

--- a/src/main/java/com/jeju/nanaland/global/file/dto/FileResponse.java
+++ b/src/main/java/com/jeju/nanaland/global/file/dto/FileResponse.java
@@ -1,0 +1,27 @@
+package com.jeju.nanaland.global.file.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+public class FileResponse {
+
+  @Data
+  @Builder
+  @Schema(description = "파트별 Pre-Signed URL 정보")
+  public static class InitResultDto {
+
+    @Schema(description = "Pre-Signed URL 정보 리스트")
+    List<PresignedUrlInfo> presignedUrlInfos;
+  }
+
+  @Data
+  @Builder
+  @Schema(description = "Pre-Signed URL 정보 리스트")
+  public static class PresignedUrlInfo {
+
+    private int partNumber;
+    private String preSignedUrl;
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
+++ b/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
@@ -1,0 +1,145 @@
+package com.jeju.nanaland.global.file.service;
+
+import static com.jeju.nanaland.global.exception.ErrorCode.INVALID_FILE_EXTENSION_TYPE;
+import static com.jeju.nanaland.global.exception.ErrorCode.INVALID_FILE_SIZE;
+import static com.jeju.nanaland.global.exception.ErrorCode.NO_FILE_EXTENSION;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.jeju.nanaland.global.exception.BadRequestException;
+import com.jeju.nanaland.global.file.data.FileCategory;
+import com.jeju.nanaland.global.file.dto.FileRequest;
+import com.jeju.nanaland.global.file.dto.FileResponse;
+import com.jeju.nanaland.global.file.dto.FileResponse.InitResultDto;
+import com.jeju.nanaland.global.file.dto.FileResponse.PresignedUrlInfo;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileUploadService {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+  @Value("${cloud.aws.s3.memberProfileDirectory}")
+  private String MEMBER_PROFILE_DIRECTORY;
+  @Value("${cloud.aws.s3.reviewDirectory}")
+  private String REVIEW_DIRECTORY;
+  @Value("${cloud.aws.s3.infoFixReportImageDirectory}")
+  private String INFO_FIX_REPORT_DIRECTORY;
+  @Value("${cloud.aws.s3.claimReportFileDirectory}")
+  private String CLAIM_REPORT_DIRECTORY;
+  private static final int PART_SIZE = 5 * 1024 * 1024;
+
+  public FileResponse.InitResultDto uploadInit(FileRequest.InitCommandDto initCommandDto) {
+    // 파일 크기 유효성 검사
+    validateFileSize(initCommandDto.getFileSize());
+
+    // 파일 형식 유효성 검사
+    validateFileExtension(initCommandDto.getOriginalFileName(), initCommandDto.getFileCategory());
+
+    // S3 key 생성
+    String fileKey = generateUniqueFileKey(initCommandDto.getOriginalFileName(),
+        initCommandDto.getFileCategory());
+
+    InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(bucket, fileKey);
+    InitiateMultipartUploadResult initResponse = amazonS3.initiateMultipartUpload(initRequest);
+    String uploadId = initResponse.getUploadId();
+
+    int partCount = calculatePartCount(initCommandDto.getFileSize());
+
+    List<PresignedUrlInfo> presignedUrlInfos = new ArrayList<>();
+    for (int partNumber = 1; partNumber <= partCount; partNumber++) {
+      GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileKey)
+          .withMethod(HttpMethod.PUT)
+          .withExpiration(getPresignedUrlExpiration())
+          .withKey(fileKey);
+
+      presignedUrlRequest.addRequestParameter("partNumber", String.valueOf(partNumber));
+      presignedUrlRequest.addRequestParameter("uploadId", uploadId);
+      URL presignedUrl = amazonS3.generatePresignedUrl(presignedUrlRequest);
+
+      presignedUrlInfos.add(PresignedUrlInfo.builder()
+          .partNumber(partNumber)
+          .preSignedUrl(presignedUrl.toString())
+          .build());
+    }
+    return InitResultDto.builder()
+        .presignedUrlInfos(presignedUrlInfos)
+        .build();
+  }
+
+  private void validateFileSize(@NotNull Long fileSize) {
+    long maxSize = 30 * 1024 * 1024L;
+    if (fileSize > maxSize) {
+      throw new BadRequestException(INVALID_FILE_SIZE.getMessage());
+    }
+  }
+
+  private void validateFileExtension(@NotBlank String originalFileName, String fileCategory) {
+    if (originalFileName == null || !originalFileName.contains(".")) {
+      throw new BadRequestException(NO_FILE_EXTENSION.getMessage());
+    }
+
+    String extension = originalFileName
+        .substring(originalFileName.lastIndexOf('.') + 1)
+        .toLowerCase();
+
+    if (!FileCategory.valueOf(fileCategory).getAllowedExtensions().contains(extension)) {
+      throw new BadRequestException(INVALID_FILE_EXTENSION_TYPE.getMessage());
+    }
+  }
+
+  private String generateUniqueFileKey(String originalFileName, String fileCategory) {
+    String extension = "";
+    if (originalFileName != null && originalFileName.contains(".")) {
+      extension = originalFileName.substring(originalFileName.lastIndexOf('.'));
+    }
+
+    String uniqueId = UUID.randomUUID().toString().substring(0, 16);
+    String formattedDate = LocalDate.now().format(DateTimeFormatter.ofPattern("yyMMdd"));
+    String fileName = uniqueId + "_" + formattedDate + extension;
+
+    return String.format("%s/%s",
+        getDirectory(FileCategory.valueOf(fileCategory)),
+        fileName);
+  }
+
+  public String getDirectory(FileCategory fileCategory) {
+    return switch (fileCategory) {
+      case MEMBER_PROFILE -> MEMBER_PROFILE_DIRECTORY;
+      case REVIEW -> REVIEW_DIRECTORY;
+      case INFO_FIX_REPORT -> INFO_FIX_REPORT_DIRECTORY;
+      case CLAIM_REPORT -> CLAIM_REPORT_DIRECTORY;
+    };
+  }
+
+  private int calculatePartCount(long fileSize) {
+    return (int) Math.ceil((double) fileSize / PART_SIZE);
+  }
+
+  private Date getPresignedUrlExpiration() {
+    Date expiration = new Date();
+    long expTimeMillis = expiration.getTime();
+    expTimeMillis += 1000 * 60 * 30;
+    expiration.setTime(expTimeMillis);
+    return expiration;
+  }
+}

--- a/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
+++ b/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
@@ -48,6 +48,8 @@ public class FileUploadService {
 
   private final AmazonS3 amazonS3;
   private final AmazonS3Client amazonS3Client;
+  @Value("${cloud.aws.cloudfront.domain}")
+  private String cloudFrontDomain;
   @Value("${cloud.aws.s3.bucket}")
   private String bucket;
   @Value("${cloud.aws.s3.memberProfileDirectory}")
@@ -194,11 +196,11 @@ public class FileUploadService {
     }
   }
 
-  public S3ImageDto getS3ImageUrls(String fileKey) {
+  public S3ImageDto getCloudImageUrls(String fileKey) {
     if (!amazonS3Client.doesObjectExist(bucket, fileKey)) {
       throw new NotFoundException(FILE_S3_NOT_FOUNE.getMessage());
     }
-    String originUrl = amazonS3.getUrl(bucket, fileKey).toString();
+    String originUrl = cloudFrontDomain + "/" + fileKey;
 
     if (!amazonS3Client.doesObjectExist(bucket + THUMBNAIL_DIRECTORY, THUMBNAIL_PREFIX + fileKey)) {
       return S3ImageDto.builder()
@@ -206,7 +208,8 @@ public class FileUploadService {
           .thumbnailUrl(originUrl)
           .build();
     }
-    String thumbnailUrl = amazonS3.getUrl(bucket + THUMBNAIL_DIRECTORY, THUMBNAIL_PREFIX + fileKey).toString();
+
+    String thumbnailUrl = cloudFrontDomain + "/" + THUMBNAIL_DIRECTORY + "/" + THUMBNAIL_PREFIX + fileKey;
     return S3ImageDto.builder()
         .originUrl(originUrl)
         .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
+++ b/src/main/java/com/jeju/nanaland/global/file/service/FileUploadService.java
@@ -82,6 +82,8 @@ public class FileUploadService {
           .build());
     }
     return InitResultDto.builder()
+        .uploadId(uploadId)
+        .fileKey(fileKey)
         .presignedUrlInfos(presignedUrlInfos)
         .build();
   }

--- a/src/main/java/com/jeju/nanaland/global/image_upload/S3ImageService.java
+++ b/src/main/java/com/jeju/nanaland/global/image_upload/S3ImageService.java
@@ -3,6 +3,7 @@ package com.jeju.nanaland.global.image_upload;
 import static com.jeju.nanaland.global.exception.ErrorCode.*;
 import static com.jeju.nanaland.global.exception.ErrorCode.EXTRACT_NAME_ERROR;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.jeju.nanaland.domain.common.entity.ImageFile;

--- a/src/test/java/com/jeju/nanaland/domain/member/service/MemberLoginServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/member/service/MemberLoginServiceTest.java
@@ -69,6 +69,8 @@ class MemberLoginServiceTest {
   private MemberConsentService memberConsentService;
   @Mock
   private FcmTokenService fcmTokenService;
+  @Mock
+  private MemberProfileService memberProfileService;
   @InjectMocks
   private MemberLoginService memberLoginService;
 
@@ -191,7 +193,7 @@ class MemberLoginServiceTest {
       doReturn(Optional.empty())
           .when(memberRepository).findByProviderAndProviderId(any(Provider.class), any(String.class));
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
-      doReturn(imageFile).when(profileImageService).saveRandomProfileImageFile();
+      doReturn(imageFile).when(memberProfileService).saveRandomProfileImageFile();
       doReturn(member).when(memberRepository).save(any(Member.class));
       doReturn("accessToken").when(jwtUtil).createAccessToken(any(String.class), anySet());
       doReturn("refreshToken").when(jwtUtil).createRefreshToken(any(String.class), anySet());
@@ -218,7 +220,7 @@ class MemberLoginServiceTest {
       doReturn(Optional.empty())
           .when(memberRepository).findByProviderAndProviderId(any(Provider.class), any(String.class));
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
-      doReturn(imageFile).when(profileImageService).saveRandomProfileImageFile();
+      doReturn(imageFile).when(memberProfileService).saveRandomProfileImageFile();
       doReturn(member).when(memberRepository).save(any(Member.class));
       doReturn("accessToken").when(jwtUtil).createAccessToken(any(String.class), anySet());
       doReturn("refreshToken").when(jwtUtil).createRefreshToken(any(String.class), anySet());
@@ -246,7 +248,7 @@ class MemberLoginServiceTest {
       doReturn(Optional.empty())
           .when(memberRepository).findByProviderAndProviderId(any(Provider.class), any(String.class));
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
-      doReturn(imageFile).when(profileImageService).saveRandomProfileImageFile();
+      doReturn(imageFile).when(memberProfileService).saveRandomProfileImageFile();
       doReturn(member).when(memberRepository).save(any(Member.class));
       doReturn("accessToken").when(jwtUtil).createAccessToken(any(String.class), anySet());
       doReturn("refreshToken").when(jwtUtil).createRefreshToken(any(String.class), anySet());
@@ -276,7 +278,7 @@ class MemberLoginServiceTest {
       doReturn(Optional.empty())
           .when(memberRepository).findByProviderAndProviderId(any(Provider.class), any(String.class));
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
-      doReturn(imageFile).when(profileImageService).saveRandomProfileImageFile();
+      doReturn(imageFile).when(memberProfileService).saveRandomProfileImageFile();
       doReturn(member).when(memberRepository).save(any(Member.class));
       doReturn("accessToken").when(jwtUtil).createAccessToken(any(String.class), anySet());
       doReturn("refreshToken").when(jwtUtil).createRefreshToken(any(String.class), anySet());

--- a/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
@@ -23,7 +23,9 @@ import com.jeju.nanaland.domain.member.repository.MemberRepository;
 import com.jeju.nanaland.global.exception.ConflictException;
 import com.jeju.nanaland.global.exception.ErrorCode;
 import com.jeju.nanaland.global.exception.NotFoundException;
+import com.jeju.nanaland.global.file.service.FileUploadService;
 import com.jeju.nanaland.global.image_upload.S3ImageService;
+import com.jeju.nanaland.global.image_upload.dto.S3ImageDto;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -37,7 +39,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +53,8 @@ class MemberProfileServiceTest {
   private ProfileImageService profileImageService;
   @InjectMocks
   private MemberProfileService memberProfileService;
+  @Mock
+  private FileUploadService fileUploadService;
 
   private MemberRequest.ProfileUpdateDto profileUpdateDto;
   private ImageFile imageFile;
@@ -121,7 +124,7 @@ class MemberProfileServiceTest {
 
       // when: 유저 프로필 수정
       ConflictException conflictException = assertThrows(ConflictException.class,
-          () -> memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, null, false));
+          () -> memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, null));
 
       // then: ErrorCode 검증
       assertThat(conflictException.getMessage()).isEqualTo(ErrorCode.NICKNAME_DUPLICATE.getMessage());
@@ -138,7 +141,7 @@ class MemberProfileServiceTest {
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
 
       // when: 유저 프로필 수정
-      memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, null, false);
+      memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, null);
 
       // then: 프로필 수정 확인, 이미지 변경 없음 확인
       assertThat(member.getNickname()).isEqualTo(profileUpdateDto.getNickname());
@@ -153,17 +156,20 @@ class MemberProfileServiceTest {
       Language language = Language.KOREAN;
       Member member = createMember(language, "nickname");
       MemberInfoDto memberInfoDto = createMemberInfoDto(language, member);
-      MultipartFile multipartFile = new MockMultipartFile("file", "test.jpg", "image/jpeg",
-          new byte[0]);
+      S3ImageDto s3ImageDto = S3ImageDto.builder()
+          .originUrl("orignUrl")
+          .thumbnailUrl("thumbnailUrl")
+          .build();
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
+      doReturn(s3ImageDto).when(fileUploadService).getS3ImageUrls(any());
 
       // when: 유저 프로필 수정
-      memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, multipartFile, false);
+      memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, "test/abc_test.jpg");
 
       // then: 프로필 수정 확인, 이미지 변경 확인
       assertThat(member.getNickname()).isEqualTo(profileUpdateDto.getNickname());
       assertThat(member.getDescription()).isEqualTo(profileUpdateDto.getDescription());
-      verify(profileImageService).updateProfileImage(any(), any());
+      verify(fileUploadService).getS3ImageUrls(any());
     }
   }
 

--- a/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/jeju/nanaland/domain/member/service/MemberProfileServiceTest.java
@@ -161,7 +161,7 @@ class MemberProfileServiceTest {
           .thumbnailUrl("thumbnailUrl")
           .build();
       doReturn(Optional.empty()).when(memberRepository).findByNickname(any(String.class));
-      doReturn(s3ImageDto).when(fileUploadService).getS3ImageUrls(any());
+      doReturn(s3ImageDto).when(fileUploadService).getCloudImageUrls(any());
 
       // when: 유저 프로필 수정
       memberProfileService.updateProfile(memberInfoDto, profileUpdateDto, "test/abc_test.jpg");
@@ -169,7 +169,7 @@ class MemberProfileServiceTest {
       // then: 프로필 수정 확인, 이미지 변경 확인
       assertThat(member.getNickname()).isEqualTo(profileUpdateDto.getNickname());
       assertThat(member.getDescription()).isEqualTo(profileUpdateDto.getDescription());
-      verify(fileUploadService).getS3ImageUrls(any());
+      verify(fileUploadService).getCloudImageUrls(any());
     }
   }
 


### PR DESCRIPTION
## 📝 Description
> 작업 내용
- preSigned URL을 적용함으로써, MultipartFile을 해당 API에서 받아오지 않기 때문에 제거합니다.
- 또한, 기존에는 S3에서의 URL을 그대로 가지고 왔다면, CloudFront가 적용된 url로 가지고 옵니다.
- 기본 프로필의 경우, 이미 이미지 사이즈가 크지 않기 때문에, originUrl와 thumbnailUrl은 동일하게 가져가려고 합니다.
- 또한, s3에 default라는 폴더를 따로 만들어서 개발용, 운영용 가리지 않고 모두 `default/Gray.png`의 형태로 고정됩니다.

<br>

## 💬 To Reviewers
- [ ] application.yml에 cloudFront 주소가 추가되었습니다.

<br>

## ☑️ Related Issue
> 관련 이슈
close #505
close #463
related to #495 